### PR TITLE
Reconciliation model refactoring in accordance with the AleRax article

### DIFF
--- a/src/ale/AleArguments.cpp
+++ b/src/ale/AleArguments.cpp
@@ -1,8 +1,9 @@
 #include "AleArguments.hpp"
 
+#include <climits>
+
 #include <IO/FileSystem.hpp>
 #include <IO/Logger.hpp>
-#include <climits>
 #include <parallelization/ParallelContext.hpp>
 
 const unsigned int DEFAULT_HIGHWAY_CANDIDATES_1 = 100;

--- a/src/ale/AleArguments.cpp
+++ b/src/ale/AleArguments.cpp
@@ -16,7 +16,7 @@ const double DEFAULT_DTL_RATES = 0.1;
 
 AleArguments::AleArguments(int iargc, char *iargv[])
     : argc(iargc), argv(iargv), reconciliationModelStr("UndatedDTL"),
-      transferConstraint(TransferConstaint::PARENTS), noTL(false),
+      transferConstraint(TransferConstaint::PARENTS), noDL(false), noTL(false),
       gammaCategories(1), pruneSpeciesTree(false),
       ccpRooting(CCPRooting::UNIFORM),
       originationStrategy(OriginationStrategy::UNIFORM), memorySavings(false),
@@ -63,6 +63,8 @@ AleArguments::AleArguments(int iargc, char *iargv[])
     } else if (arg == "--transfer-constraint") {
       transferConstraint =
           ArgumentsHelper::strToTransferConstraint(std::string(argv[++i]));
+    } else if (arg == "--no-dl") {
+      noDL = true;
     } else if (arg == "--no-tl") {
       noTL = true;
     } else if (arg == "--memory-savings") {
@@ -188,6 +190,12 @@ void AleArguments::printSummary() const {
   case TransferConstaint::RELDATED:
     Logger::info << "transfers to the past are forbidden" << std::endl;
     break;
+  }
+  if (noDL) {
+    Logger::info << "\tThe model will not consider DL events" << std::endl;
+  }
+  if (noTL) {
+    Logger::info << "\tThe model will not consider TL events" << std::endl;
   }
   Logger::info << "\tMemory savings: " << getOnOff(memorySavings) << std::endl;
   Logger::info << "\tModel parametrization: ";
@@ -364,6 +372,8 @@ void AleArguments::printHelp() const {
   Logger::info << "\t--gene-tree-rooting {UNIFORM, MAD, ROOTED}" << std::endl;
   Logger::info << "\t--prune-species-tree" << std::endl;
   Logger::info << "\t--fraction-missing-file <filepath>" << std::endl;
+  Logger::info << "\t--no-dl" << std::endl;
+  Logger::info << "\t--no-tl" << std::endl;
   Logger::info << "\t--memory-savings" << std::endl;
 
   Logger::info << "Search strategy options:" << std::endl;
@@ -440,6 +450,12 @@ void AleArguments::checkValid() const {
                    << "with --rec-model UndatedDTL\n"
                    << std::endl;
     }
+    if (noTL) {
+      ok = false;
+      Logger::info << "\nError: --no-tl can only be used "
+                   << "with --rec-model UndatedDTL\n"
+                   << std::endl;
+    }
     if (highways) {
       ok = false;
       Logger::info << "\nError: --highways can only be used "
@@ -468,8 +484,15 @@ void AleArguments::checkValid() const {
       originationStrategy != OriginationStrategy::OPTIMIZE) {
     ok = false;
     Logger::info << "\nError: --model-parametrization ORIGINATION-PER-SPECIES "
-                    "should only be used "
+                    "can only be used "
                  << "with --origination OPTIMIZE\n"
+                 << std::endl;
+  }
+  if (modelParametrization == ModelParametrization::PER_FAMILY &&
+      gammaCategories > 1) {
+    ok = false;
+    Logger::info << "\nError: --speciation-gamma-categories cannot be used "
+                 << "with --model-parametrization PER-FAMILY\n"
                  << std::endl;
   }
   // reldating block

--- a/src/ale/AleArguments.hpp
+++ b/src/ale/AleArguments.hpp
@@ -13,7 +13,7 @@ public:
   /**
    *  Parse the arguments from main()
    */
-  AleArguments(int argc, char *argv[]);
+  AleArguments(int iargc, char *iargv[]);
 
   /**
    *  Print AleRax' help message
@@ -60,6 +60,7 @@ public:
   // model
   std::string reconciliationModelStr;
   TransferConstaint transferConstraint;
+  bool noDL;
   bool noTL;
   unsigned int gammaCategories;
   bool pruneSpeciesTree;

--- a/src/ale/AleArguments.hpp
+++ b/src/ale/AleArguments.hpp
@@ -1,8 +1,9 @@
 #pragma once
 
+#include <string>
+
 #include "IO/ArgumentsHelper.hpp"
 #include "util/enums.hpp"
-#include <string>
 
 /**
  *  Parses and stores the program arguments

--- a/src/ale/AleEvaluator.cpp
+++ b/src/ale/AleEvaluator.cpp
@@ -9,12 +9,12 @@
 #include <parallelization/ParallelContext.hpp>
 #include <search/SpeciesTransferSearch.hpp>
 
-static std::shared_ptr<MultiModel>
+static MultiEvaluationPtr
 createModel(SpeciesTree &speciesTree, const FamilyInfo &family,
             const RecModelInfo &info, const double alpha,
             const AleModelParameters &modelParameters,
             const std::vector<Highway> &highways, bool highPrecision) {
-  std::shared_ptr<MultiModel> model;
+  std::shared_ptr<MultiModelInterface> model;
   GeneSpeciesMapping mapping;
   mapping.fill(family.mappingFile, family.startingGeneTree);
   switch (info.model) {
@@ -380,7 +380,6 @@ void AleEvaluator::sampleFamilyScenarios(
     std::vector<std::shared_ptr<Scenario>> &scenarios) {
   assert(i < getLocalFamilyNumber());
   scenarios.clear();
-  getEvaluation(i).computeLogLikelihood();
   bool ok = getEvaluation(i).sampleReconciliations(samples, scenarios);
   if (_highPrecisions[i] == -1 && !ok) {
     // We are in the low precision mode (we use double)
@@ -420,7 +419,6 @@ void AleEvaluator::getTransferInformation(
     mapping.fill(family.mappingFile, family.startingGeneTree);
     UndatedDTLMultiModel<ScaledValue> evaluation(speciesTree.getDatedTree(),
                                                  mapping, infoCopy, family.ccp);
-    evaluation.computeLogLikelihood();
     std::vector<std::shared_ptr<Scenario>> scenarios;
     // Warning:
     // Using Random::getProba() in the sampling function makes

--- a/src/ale/AleEvaluator.cpp
+++ b/src/ale/AleEvaluator.cpp
@@ -1,9 +1,10 @@
 #include "AleOptimizer.hpp"
 
-#include <IO/Logger.hpp>
 #include <algorithm>
 #include <fstream>
 #include <memory>
+
+#include <IO/Logger.hpp>
 #include <optimizers/DTLOptimizer.hpp>
 #include <parallelization/ParallelContext.hpp>
 #include <search/SpeciesTransferSearch.hpp>

--- a/src/ale/AleEvaluator.hpp
+++ b/src/ale/AleEvaluator.hpp
@@ -1,13 +1,14 @@
 #pragma once
 
+#include <memory>
+#include <vector>
+
 #include <IO/Families.hpp>
 #include <maths/ModelParameters.hpp>
-#include <memory>
 #include <parallelization/PerCoreGeneTrees.hpp>
 #include <search/SpeciesSearchCommon.hpp>
 #include <trees/PLLRootedTree.hpp>
 #include <trees/SpeciesTree.hpp>
-#include <vector>
 
 #include "AleModelParameters.hpp"
 #include "OptimizationClasses.hpp"

--- a/src/ale/AleEvaluator.hpp
+++ b/src/ale/AleEvaluator.hpp
@@ -4,7 +4,6 @@
 #include <vector>
 
 #include <IO/Families.hpp>
-#include <maths/ModelParameters.hpp>
 #include <parallelization/PerCoreGeneTrees.hpp>
 #include <search/SpeciesSearchCommon.hpp>
 #include <trees/PLLRootedTree.hpp>
@@ -16,7 +15,7 @@
 #include "UndatedDTLMultiModel.hpp"
 
 class RecModelInfo;
-using MultiEvaluation = MultiModel;
+using MultiEvaluation = MultiModelInterface;
 using MultiEvaluationPtr = std::shared_ptr<MultiEvaluation>;
 using PerCoreMultiEvaluations = std::vector<MultiEvaluationPtr>;
 class AleOptimizer;
@@ -174,7 +173,7 @@ public:
     return _modelParameters;
   }
   const std::vector<Highway> &getHighways() const { return _highways; }
-  MultiModel &getEvaluation(unsigned int i) { return *_evaluations[i]; }
+  MultiEvaluation &getEvaluation(unsigned int i) { return *_evaluations[i]; }
   unsigned int getLocalFamilyNumber() const {
     return _geneTrees.getTrees().size();
   }

--- a/src/ale/AleModelParameters.hpp
+++ b/src/ale/AleModelParameters.hpp
@@ -3,7 +3,7 @@
 #include <algorithm>
 #include <vector>
 
-#include <maths/ModelParameters.hpp>
+#include <maths/Parameters.hpp>
 #include <util/types.hpp>
 
 /**

--- a/src/ale/AleModelParameters.hpp
+++ b/src/ale/AleModelParameters.hpp
@@ -1,9 +1,10 @@
 #pragma once
 
 #include <algorithm>
+#include <vector>
+
 #include <maths/ModelParameters.hpp>
 #include <util/types.hpp>
-#include <vector>
 
 /**
  * Stores the model parameters for a gene family

--- a/src/ale/AleOptimizer.hpp
+++ b/src/ale/AleOptimizer.hpp
@@ -1,14 +1,15 @@
 #pragma once
 
+#include <memory>
+#include <vector>
+
 #include <IO/Families.hpp>
 #include <IO/FileSystem.hpp>
 #include <maths/ModelParameters.hpp>
-#include <memory>
 #include <optimizers/DTLOptimizer.hpp>
 #include <parallelization/PerCoreGeneTrees.hpp>
 #include <trees/PLLRootedTree.hpp>
 #include <trees/SpeciesTree.hpp>
-#include <vector>
 
 #include "AleEvaluator.hpp"
 #include "AleState.hpp"

--- a/src/ale/AleOptimizer.hpp
+++ b/src/ale/AleOptimizer.hpp
@@ -5,7 +5,6 @@
 
 #include <IO/Families.hpp>
 #include <IO/FileSystem.hpp>
-#include <maths/ModelParameters.hpp>
 #include <optimizers/DTLOptimizer.hpp>
 #include <parallelization/PerCoreGeneTrees.hpp>
 #include <trees/PLLRootedTree.hpp>

--- a/src/ale/AleState.cpp
+++ b/src/ale/AleState.cpp
@@ -1,9 +1,10 @@
 #include "AleState.hpp"
 
+#include <unordered_set>
+
 #include <IO/FileSystem.hpp>
 #include <IO/ParallelOfstream.hpp>
 #include <parallelization/ParallelContext.hpp>
-#include <unordered_set>
 
 void AleState::writeCheckpointCmd(const std::string &currentCmd,
                                   const std::string &checkpointDir) {

--- a/src/ale/AleState.hpp
+++ b/src/ale/AleState.hpp
@@ -1,10 +1,11 @@
 #pragma once
 
+#include <string>
+#include <vector>
+
 #include <IO/Families.hpp>
 #include <IO/HighwayCandidateParser.hpp>
-#include <string>
 #include <trees/SpeciesTree.hpp>
-#include <vector>
 
 #include "AleModelParameters.hpp"
 

--- a/src/ale/Highways.hpp
+++ b/src/ale/Highways.hpp
@@ -1,7 +1,8 @@
 #pragma once
 
-#include <IO/HighwayCandidateParser.hpp>
 #include <vector>
+
+#include <IO/HighwayCandidateParser.hpp>
 
 class AleOptimizer;
 

--- a/src/ale/MultiModel.hpp
+++ b/src/ale/MultiModel.hpp
@@ -1,15 +1,19 @@
 #pragma once
 
-#include "util/enums.hpp"
 #include <IO/HighwayCandidateParser.hpp>
-#include <IO/LibpllParsers.hpp>
 #include <ccp/ConditionalClades.hpp>
 #include <likelihoods/reconciliation_models/BaseReconciliationModel.hpp>
-#include <memory>
 
 class GeneSpeciesMapping;
 class PLLRootedTree;
+class RecModelInfo;
+class ScaledValue;
+class Scenario;
 
+/**
+ *  Temp storage for a clade event sampled in
+ *  the reconciliation space
+ */
 template <class REAL> struct ReconciliationCell {
   Scenario::Event event;
   REAL maxProba;
@@ -17,65 +21,31 @@ template <class REAL> struct ReconciliationCell {
   double blRight;
 };
 
-#define EXCLUDE_ABOVE_PRUNED
-#define EXCLUDE_DEAD_NODES
-#define COMPUTE_TL
-
-// helper function for updateSpeciesToPrunedNode
-static void
-auxUntilPrunedRoot(corax_rnode_t *speciesNode, corax_rnode_t *prunedRoot,
-                   std::vector<corax_rnode_t *> &speciesToPrunedNode) {
-  assert(speciesNode);
-  assert(prunedRoot);
-  speciesToPrunedNode[speciesNode->node_index] = prunedRoot;
-  if (speciesNode == prunedRoot) {
-    return;
-  }
-  if (speciesNode->left) {
-    assert(speciesNode->right);
-    auxUntilPrunedRoot(speciesNode->left, prunedRoot, speciesToPrunedNode);
-    auxUntilPrunedRoot(speciesNode->right, prunedRoot, speciesToPrunedNode);
-  }
-}
-
-// helper function for updateSpeciesToPrunedNode
-static void
-fillUnsampledSpeciesRec(corax_rnode_t *unsampledNode,
-                        corax_rnode_t *prunedNodeToAssign,
-                        std::vector<corax_rnode_t *> &speciesToPrunedNode) {
-  speciesToPrunedNode[unsampledNode->node_index] = prunedNodeToAssign;
-  if (unsampledNode->left) {
-    fillUnsampledSpeciesRec(unsampledNode->left, prunedNodeToAssign,
-                            speciesToPrunedNode);
-    fillUnsampledSpeciesRec(unsampledNode->right, prunedNodeToAssign,
-                            speciesToPrunedNode);
-  }
-}
-
 /**
- * Base class for reconciliation models that take as input
- * gene tree distributions (represented by conditional clade
- * probabilities)
+ *  Base class for reconciliation models that take as input
+ *  gene tree distributions (represented by conditional clade
+ *  probabilities)
  */
-class MultiModel : public BaseReconciliationModel {
+class MultiModelInterface : public BaseReconciliationModel {
 public:
-  MultiModel(PLLRootedTree &speciesTree,
-             const GeneSpeciesMapping &geneSpeciesMapping,
-             const RecModelInfo &info, const std::string &ccpFile)
+  MultiModelInterface(PLLRootedTree &speciesTree,
+                      const GeneSpeciesMapping &geneSpeciesMapping,
+                      const RecModelInfo &info, const std::string &ccpFile)
       : BaseReconciliationModel(speciesTree, geneSpeciesMapping, info),
         _memorySavings(info.memorySavings) {
     _ccp.unserialize(ccpFile);
     mapGenesToSpecies();
   }
-  virtual ~MultiModel() {}
+
+  virtual ~MultiModelInterface() {}
 
   const ConditionalClades &getCCP() const { return _ccp; }
 
+  virtual void setAlpha(double alpha) = 0;
+  virtual void setRates(const RatesVector &rates) = 0;
   virtual void setHighways(const std::vector<Highway> &highways) {
     (void)(highways);
   }
-
-  virtual void onSpeciesDatesChange() {}
 
   virtual void onSpeciesTreeChange(
       const std::unordered_set<corax_rnode_t *> *nodesToInvalidate) {
@@ -83,236 +53,392 @@ public:
     updateSpeciesToPrunedNode();
   }
 
+  virtual double computeLogLikelihood() = 0;
+
+  virtual bool inferMLScenario(Scenario &scenario) = 0;
+
   virtual bool
   sampleReconciliations(unsigned int samples,
                         std::vector<std::shared_ptr<Scenario>> &scenarios) = 0;
 
 protected:
-  // methods used to handle memory in memory saving mode
-  virtual void allocateMemory() {}
-  virtual void deallocateMemory() {}
-  virtual void updateCLVs() {}
-  corax_rnode_t *getSpeciesLCA() {
-    auto tree = &this->_speciesTree;
-    corax_rnode_t *lca = nullptr;
-    for (auto it : this->_speciesNameToId) {
-      auto spid = it.second;
-      auto node = tree->getNode(spid);
-      lca = tree->getLCA(lca, node);
-    }
-    return _speciesToPrunedNode[lca->node_index];
+  // get the LCA of all species covered by the gene family
+  corax_rnode_t *getCoveredSpeciesLCA() {
+    return _speciesToPrunedNode[this->getPrunedRoot()->node_index];
   }
 
-  virtual void updateSpeciesToPrunedNode() {
-    if (!_speciesToPrunedNode.size()) {
-      _speciesToPrunedNode.resize(this->getAllSpeciesNodeNumber());
-    }
-    std::fill(_speciesToPrunedNode.begin(), _speciesToPrunedNode.end(),
-              nullptr);
-    for (auto speciesNode : this->getAllSpeciesNodes()) {
-      auto e = speciesNode->node_index;
-      if (speciesNode->left) {
-        auto left = speciesNode->left->node_index;
-        auto right = speciesNode->right->node_index;
-        if (_speciesToPrunedNode[left] && _speciesToPrunedNode[right]) {
-          // this node belongs to the pruned nodes
-          _speciesToPrunedNode[e] = speciesNode;
-        } else if (_speciesToPrunedNode[left]) {
-          _speciesToPrunedNode[e] = _speciesToPrunedNode[left];
-#ifndef EXCLUDE_DEAD_NODES
-          fillUnsampledSpeciesRec(speciesNode->right, _speciesToPrunedNode[e],
-                                  _speciesToPrunedNode);
-#endif
-        } else if (_speciesToPrunedNode[right]) {
-          _speciesToPrunedNode[e] = _speciesToPrunedNode[right];
-#ifndef EXCLUDE_DEAD_NODES
-          fillUnsampledSpeciesRec(speciesNode->left, _speciesToPrunedNode[e],
-                                  _speciesToPrunedNode);
-#endif
-        } // else do nothing
-      } else {
-        if (this->_speciesCoverage[e]) {
-          _speciesToPrunedNode[e] = speciesNode;
-        }
-      }
-    }
-    // if the  root of the pruned species tree is not the root, we need
-    // to map all parents and siblings of the pruned root to the pruned root
-#ifndef EXCLUDE_ABOVE_PRUNED
-    auxUntilPrunedRoot(this->getSpeciesTree().getRoot(), this->getPrunedRoot(),
-                       _speciesToPrunedNode);
-#endif
-  }
+  // should be called on changing model rates (alpha/DTLO/
+  // highways), as the LLs computed earlier become irrelevant
+  void resetCache() { _llCache.clear(); }
 
-  void mapGenesToSpecies() {
-    const auto &cidToLeaves = _ccp.getCidToLeaves();
-    this->_speciesNameToId.clear();
-    this->_geneToSpecies.resize(_ccp.getCladesNumber());
-    for (auto node : this->_allSpeciesNodes) {
-      if (!node->left) {
-        this->_speciesNameToId[node->label] = node->node_index;
-      }
-    }
-    this->_speciesCoverage =
-        std::vector<unsigned int>(this->getAllSpeciesNodeNumber(), 0);
-    for (auto p : cidToLeaves) {
-      auto cid = p.first;
-      const auto &geneName = cidToLeaves.at(cid);
-      const auto &speciesName = this->_geneNameToSpeciesName[geneName];
-      this->_geneToSpecies[cid] = this->_speciesNameToId[speciesName];
-      this->_speciesCoverage[this->_geneToSpecies[cid]]++;
-    }
-  }
+private:
+  virtual void mapGenesToSpecies();
+  // map each species node not covered by the gene family
+  // to its closest covered child if any
+  void updateSpeciesToPrunedNode();
+
+protected:
+  const bool _memorySavings;
   ConditionalClades _ccp;
-  bool _memorySavings;
   std::vector<corax_rnode_t *> _speciesToPrunedNode;
+  std::unordered_map<size_t, double> _llCache;
 };
 
+inline void MultiModelInterface::mapGenesToSpecies() {
+  // fill _geneToSpecies, _speciesCoverage and _numberOfCoveredSpecies
+  this->_geneToSpecies.clear();
+  this->_speciesCoverage.resize(this->_speciesTree.getLeafNumber(), 0);
+  this->_numberOfCoveredSpecies = 0;
+  const auto &cidToLeaves = _ccp.getCidToLeaves();
+  for (const auto &p : cidToLeaves) {
+    const auto cid = p.first;
+    const auto &geneName = p.second;
+    const auto &speciesName = this->_geneNameToSpeciesName[geneName];
+    const auto spid = this->_speciesNameToId[speciesName];
+    this->_geneToSpecies[cid] = spid;
+    if (!this->_speciesCoverage[spid]) {
+      this->_numberOfCoveredSpecies++;
+    }
+    this->_speciesCoverage[spid]++;
+  }
+  // build the pruned species tree representation based
+  // on the species coverage
+  onSpeciesTreeChange(nullptr);
+}
+
+inline void MultiModelInterface::updateSpeciesToPrunedNode() {
+  if (!_speciesToPrunedNode.size()) {
+    _speciesToPrunedNode.resize(this->getAllSpeciesNodeNumber());
+  }
+  std::fill(_speciesToPrunedNode.begin(), _speciesToPrunedNode.end(), nullptr);
+  for (auto speciesNode : this->getAllSpeciesNodes()) {
+    auto e = speciesNode->node_index;
+    if (speciesNode->left) {
+      auto left = speciesNode->left->node_index;
+      auto right = speciesNode->right->node_index;
+      if (_speciesToPrunedNode[left] && _speciesToPrunedNode[right]) {
+        // this node belongs to the pruned nodes
+        _speciesToPrunedNode[e] = speciesNode;
+      } else if (_speciesToPrunedNode[left]) {
+        _speciesToPrunedNode[e] = _speciesToPrunedNode[left];
+      } else if (_speciesToPrunedNode[right]) {
+        _speciesToPrunedNode[e] = _speciesToPrunedNode[right];
+      } // else do nothing
+    } else {
+      if (this->_speciesCoverage[e]) {
+        _speciesToPrunedNode[e] = speciesNode;
+      }
+    }
+  }
+}
+
 /**
- * Implements all basic methods required by the child classes
- * and that require the REAL template
+ *  Implements all the methods that require the REAL template
+ *  and are not dependent on modelling HGT
  */
-template <class REAL> class MultiModelTemplate : public MultiModel {
+template <class REAL> class MultiModel : public MultiModelInterface {
 public:
-  MultiModelTemplate(PLLRootedTree &speciesTree,
-                     const GeneSpeciesMapping &geneSpeciesMapping,
-                     const RecModelInfo &info, const std::string &ccpFile)
-      : MultiModel(speciesTree, geneSpeciesMapping, info, ccpFile) {}
-  virtual ~MultiModelTemplate() {}
+  MultiModel(PLLRootedTree &speciesTree,
+             const GeneSpeciesMapping &geneSpeciesMapping,
+             const RecModelInfo &info, const std::string &ccpFile)
+      : MultiModelInterface(speciesTree, geneSpeciesMapping, info, ccpFile) {}
+
+  virtual ~MultiModel() {}
+
   /**
-   * Samples a reconciled gene tree and stores it into
-   * scenario
+   *  Compute the LL of the current species tree
+   */
+  virtual double computeLogLikelihood();
+
+  /**
+   *  Find the ML reconciled gene tree and store it in
+   *  the scenario variable
    */
   virtual bool inferMLScenario(Scenario &scenario);
 
   /**
-   *  Sample scenarios and add them to the scenarios vector
+   *  Sample reconciled gene trees and add them to
+   *  the scenarios vector
    */
   virtual bool
   sampleReconciliations(unsigned int samples,
                         std::vector<std::shared_ptr<Scenario>> &scenarios);
 
 protected:
-  /**
-   * Sample the species node from with the sampled gene tree
-   * originates. The implementation depends on the origination
-   * mode (unifor, from the root etc.)
-   */
-  virtual corax_rnode_t *sampleSpeciesNode(unsigned int &category) = 0;
+  // functions to work with CLVs
+  virtual void allocateMemory() = 0;
+  virtual void deallocateMemory() = 0;
+  virtual void updateCLV(CID cid) = 0;
 
-private:
   /**
-   * Compute the CLV for a given cid (clade id) and a
-   * given species node. Returns true in case of sucess
-   * If recCell is set, the function samples the next
-   * event in the reconciliation space
+   *  Probability of an arbitrary gene family to originate
+   *  somewhere in the species tree and survive (at least as
+   *  a single copy on a single leaf).
+   *  All possible reconciliations of the current family are
+   *  included by this scenario, thus it is the conditioning
+   *  probability
+   */
+  virtual double getLikelihoodFactor(unsigned int category) = 0;
+
+  /**
+   *  Probability of the current family to evolve starting
+   *  from a given species branch.
+   *  Sum over all scenarios stemming from the species branch
+   */
+  virtual REAL getRootCladeLikelihood(corax_rnode_t *speciesNode,
+                                      unsigned int category) = 0;
+
+  /**
+   *  Compute the CLV value for a given cid (clade id) and a given
+   *  species node. Return true in case of success.
+   *  If recCell is set, sample the next event in the reconciliation
+   *  space
    */
   virtual bool
-  computeProbability(CID cid, corax_rnode_t *speciesNode, size_t category,
+  computeProbability(CID cid, corax_rnode_t *speciesNode, unsigned int category,
                      REAL &proba,
                      ReconciliationCell<REAL> *recCell = nullptr) = 0;
 
   /**
-   * Recursively sample a reconciled gene tree
+   *  Return a uniform random REAL from the [0,max) interval
    */
-  bool backtrace(unsigned int cid, corax_rnode_t *speciesRoot,
-                 corax_unode_t *geneNode, unsigned int category,
-                 Scenario &scenario, bool stochastic);
-  bool _computeScenario(Scenario &scenario, bool stochastic);
+  REAL getRandom(REAL max) {
+    auto rand = max * Random::getProba();
+    scale(rand);
+    if (rand == max) { // may occur due to rounding issues
+      rand = REAL();
+    }
+    return rand;
+  }
+
+private:
+  /**
+   *  Return an undated or dated species tree hash
+   */
+  virtual size_t getHash() = 0;
+
+  /**
+   *  Number of mixture categories for the per-branch
+   *  probabilities of elementary events
+   */
+  unsigned int getGammaCatNumber() { return this->_info.gammaCategories; }
+
+  /**
+   *  Fill CLV for each observed gene clade
+   */
+  void updateCLVs();
+
+  /**
+   *  Jointly sample a category and a species branch based on
+   *  the probability of the gene tree to be rooted in it
+   */
+  corax_rnode_t *sampleOriginationSpecies(unsigned int &category);
+
+  /**
+   *  Wrapper for the backtrace function
+   */
+  bool computeScenario(Scenario &scenario, bool stochastic);
+
+  /**
+   *  Recursively sample a reconciled gene tree
+   */
+  bool backtrace(CID cid, corax_rnode_t *speciesNode, corax_unode_t *geneNode,
+                 unsigned int category, Scenario &scenario, bool stochastic);
 };
 
-template <class REAL>
-bool MultiModelTemplate<REAL>::sampleReconciliations(
-    unsigned int samples, std::vector<std::shared_ptr<Scenario>> &scenarios) {
-  allocateMemory();
+template <class REAL> double MultiModel<REAL>::computeLogLikelihood() {
+  if (this->_ccp.skip()) {
+    return 0.0;
+  }
+  auto hash = getHash();
+  // check if LL is already computed for this species tree
+  auto cacheIt = this->_llCache.find(hash);
+  if (cacheIt != this->_llCache.end()) {
+    if (!this->_info.isDated()) // too many collisions for dated getHash(), del
+                                // the line upon fixing
+      return cacheIt->second;
+  }
+  if (this->_memorySavings) {
+    // initialize CLVs, as they have not been created with the model
+    allocateMemory();
+  }
+  // compute CLVs based on the recomputed per-branch probas
   updateCLVs();
+  // compute the species tree LL
+  REAL res = REAL();
+  std::vector<REAL> categoryLikelihoods(getGammaCatNumber(), REAL());
+  for (unsigned int c = 0; c < getGammaCatNumber(); ++c) {
+    for (auto speciesNode : this->getPrunedSpeciesNodes()) {
+      categoryLikelihoods[c] += getRootCladeLikelihood(speciesNode, c);
+    }
+    // condition on survival
+    categoryLikelihoods[c] /=
+        getLikelihoodFactor(c); // no need to scale here as factor <= 1.0
+  }
+  // sum over the categories
+  res = std::accumulate(categoryLikelihoods.begin(), categoryLikelihoods.end(),
+                        REAL());
+  // normalize by the number of categories
+  res /= static_cast<double>(getGammaCatNumber());
+  scale(res);
+  auto ll = log(res);
+  // remember the computed LL for this species tree
+  this->_llCache[hash] = ll;
+  if (this->_memorySavings) {
+    // delete CLVs to use less RAM
+    deallocateMemory();
+  }
+  return ll;
+}
+
+template <class REAL>
+bool MultiModel<REAL>::inferMLScenario(Scenario &scenario) {
+  assert(false); // not implemented for MultiModel
+  return computeScenario(scenario, false);
+}
+
+template <class REAL>
+bool MultiModel<REAL>::sampleReconciliations(
+    unsigned int samples, std::vector<std::shared_ptr<Scenario>> &scenarios) {
+  if (this->_memorySavings) {
+    // initialize CLVs, as they have not been created with the model
+    allocateMemory();
+  }
+  // compute CLVs based on the recomputed per-branch probas
+  updateCLVs();
+  // sample and save scenarios
+  bool ok = true;
   for (unsigned int i = 0; i < samples; ++i) {
     scenarios.push_back(std::make_shared<Scenario>());
-    if (!_computeScenario(*scenarios.back(), true)) {
-      deallocateMemory();
-      return false;
+    ok &= computeScenario(*scenarios.back(), true);
+    if (!ok)
+      break;
+  }
+  if (this->_memorySavings) {
+    // delete CLVs to use less RAM
+    deallocateMemory();
+  }
+  return ok;
+}
+
+template <class REAL> void MultiModel<REAL>::updateCLVs() {
+  // recompute the per-branch probas of elementary events
+  this->beforeComputeCLVs();
+  // perform updateCLV() for each observed gene clade:
+  // postorder gene clade traversal is granted
+  for (CID cid = 0; cid < this->_ccp.getCladesNumber(); ++cid) {
+    updateCLV(cid);
+  }
+  this->_allSpeciesNodesInvalid = false;
+  this->_invalidatedSpeciesNodes.clear();
+}
+
+template <class REAL>
+corax_rnode_t *
+MultiModel<REAL>::sampleOriginationSpecies(unsigned int &category) {
+  auto totalLikelihood = REAL();
+  for (unsigned int c = 0; c < getGammaCatNumber(); ++c) {
+    for (auto speciesNode : this->getPrunedSpeciesNodes()) {
+      totalLikelihood += getRootCladeLikelihood(speciesNode, c);
     }
   }
-  deallocateMemory();
-  return true;
+  auto toSample = getRandom(totalLikelihood);
+  auto sumLikelihood = REAL();
+  for (unsigned int c = 0; c < getGammaCatNumber(); ++c) {
+    for (auto speciesNode : this->getPrunedSpeciesNodes()) {
+      sumLikelihood += getRootCladeLikelihood(speciesNode, c);
+      if (sumLikelihood > toSample) {
+        category = c;
+        return speciesNode;
+      }
+    }
+  }
+  assert(false);
+  return nullptr;
 }
 
 template <class REAL>
-bool MultiModelTemplate<REAL>::inferMLScenario(Scenario &scenario) {
-  assert(false); // not implemented for MultiModel
-  return _computeScenario(scenario, false);
-}
-
-template <class REAL>
-bool MultiModelTemplate<REAL>::_computeScenario(Scenario &scenario,
-                                                bool stochastic) {
+bool MultiModel<REAL>::computeScenario(Scenario &scenario, bool stochastic) {
   assert(stochastic);
-  unsigned int category = 0;
   auto rootCID = this->_ccp.getCladesNumber() - 1;
-  auto speciesRoot = sampleSpeciesNode(category);
-  auto rootIndex = 2 * _ccp.getLeafNumber();
-  scenario.setVirtualRootIndex(rootIndex);
+  // sample rate category and origination species
+  unsigned int category = 0;
+  auto originationSpecies = sampleOriginationSpecies(category);
+  // init scenario
   scenario.setSpeciesTree(&this->_speciesTree);
-  auto virtualGeneRoot = scenario.generateVirtualGeneRoot();
-  scenario.setGeneRoot(virtualGeneRoot);
-  auto res = backtrace(rootCID, speciesRoot, virtualGeneRoot, category,
-                       scenario, stochastic);
-  return res;
+  auto geneRoot = scenario.generateGeneRoot();
+  scenario.setGeneRoot(geneRoot);
+  auto virtualRootIndex = 2 * _ccp.getLeafNumber();
+  scenario.setVirtualRootIndex(virtualRootIndex);
+  // run sampling recursion
+  auto ok = backtrace(rootCID, originationSpecies, geneRoot, category, scenario,
+                      stochastic);
+  return ok;
 }
 
 template <class REAL>
-bool MultiModelTemplate<REAL>::backtrace(unsigned int cid,
-                                         corax_rnode_t *speciesNode,
-                                         corax_unode_t *geneNode,
-                                         unsigned int category,
-                                         Scenario &scenario, bool stochastic) {
+bool MultiModel<REAL>::backtrace(CID cid, corax_rnode_t *speciesNode,
+                                 corax_unode_t *geneNode, unsigned int category,
+                                 Scenario &scenario, bool stochastic) {
+  auto c = category;
+  // compute the probability of the clade on the species branch
+  // under all possible scenarios
   REAL proba;
-  if (!computeProbability(cid, speciesNode, category, proba)) {
+  if (!computeProbability(cid, speciesNode, c, proba)) {
     return false;
   }
+  // set sampling probability and sample a clade event of the clade
+  // on the species branch
   ReconciliationCell<REAL> recCell;
-  recCell.maxProba = proba * Random::getProba();
-  if (!computeProbability(cid, speciesNode, category, proba, &recCell)) {
+  recCell.event.previousType = scenario.getLastEventType();
+  recCell.maxProba = getRandom(proba);
+  if (!computeProbability(cid, speciesNode, c, proba, &recCell)) {
     return false;
   }
+  // overwrite the recCell's self gene node index:
+  // replace the cid of the current clade with
+  // the current node index of the reconciled gene tree
   if (scenario.getGeneNodeBuffer().size() == 1) {
     recCell.event.geneNode = scenario.getVirtualRootIndex();
   } else {
     recCell.event.geneNode = geneNode->node_index;
   }
-
+  // overwrite the recCell's child node indices:
+  // replace the cids of the sampled child clades with
+  // the accordingly built child nodes of the reconciled gene tree
+  CID leftCid = 0;
+  CID rightCid = 0;
   corax_unode_t *leftGeneNode;
   corax_unode_t *rightGeneNode;
-  auto leftCid = recCell.event.leftGeneIndex;
-  auto rightCid = recCell.event.rightGeneIndex;
   if (recCell.event.type == ReconciliationEventType::EVENT_S ||
       recCell.event.type == ReconciliationEventType::EVENT_D ||
       recCell.event.type == ReconciliationEventType::EVENT_T) {
+    // save the original clade indices
+    leftCid = recCell.event.leftGeneIndex;
+    rightCid = recCell.event.rightGeneIndex;
+    // make child nodes for the scenario
     scenario.generateGeneChildren(geneNode, leftGeneNode, rightGeneNode);
-    recCell.event.leftGeneIndex = leftGeneNode->node_index;
-    recCell.event.rightGeneIndex = rightGeneNode->node_index;
     leftGeneNode->length = recCell.blLeft;
     rightGeneNode->length = recCell.blRight;
-    recCell.event.previous_event_type = scenario.getLastEventType();
+    recCell.event.leftGeneIndex = leftGeneNode->node_index;
+    recCell.event.rightGeneIndex = rightGeneNode->node_index;
   }
+  // add the overwritten recCell event to the scenario
   bool addEvent = true;
-  if ((recCell.event.type == ReconciliationEventType::EVENT_TL &&
-       recCell.event.pllDestSpeciesNode == nullptr) ||
-      recCell.event.type == ReconciliationEventType::EVENT_DL) {
+  if (recCell.event.type == ReconciliationEventType::EVENT_DL ||
+      (recCell.event.type == ReconciliationEventType::EVENT_TL &&
+       recCell.event.pllDestSpeciesNode == nullptr)) {
     addEvent = false;
   }
-
   if (addEvent) {
     scenario.addEvent(recCell.event);
   }
-
+  // recursion to sample for the child clades or to resample
   bool ok = true;
-  std::string label;
-  auto c = category;
-
-  scenario.setLastEventType(recCell.event.type);
+  std::string geneLabel;
   switch (recCell.event.type) {
   case ReconciliationEventType::EVENT_S:
+    scenario.setLastEventType(recCell.event.type);
     ok &= backtrace(leftCid, this->getSpeciesLeft(speciesNode), leftGeneNode, c,
                     scenario, stochastic);
     scenario.setLastEventType(recCell.event.type);
@@ -320,34 +446,34 @@ bool MultiModelTemplate<REAL>::backtrace(unsigned int cid,
                     c, scenario, stochastic);
     break;
   case ReconciliationEventType::EVENT_D:
+    scenario.setLastEventType(recCell.event.type);
     ok &=
         backtrace(leftCid, speciesNode, leftGeneNode, c, scenario, stochastic);
     scenario.setLastEventType(recCell.event.type);
     ok &= backtrace(rightCid, speciesNode, rightGeneNode, c, scenario,
                     stochastic);
     break;
-  case ReconciliationEventType::EVENT_DL:
-    scenario.setLastEventType(ReconciliationEventType::EVENT_S);
-    ok &= backtrace(cid, speciesNode, geneNode, c, scenario, stochastic);
-    break;
-  case ReconciliationEventType::EVENT_SL:
-    ok &= backtrace(cid, recCell.event.pllDestSpeciesNode, geneNode, c,
-                    scenario, stochastic);
-    break;
   case ReconciliationEventType::EVENT_T:
     // source species
-    scenario.setLastEventType(ReconciliationEventType::EVENT_S);
     ok &=
         backtrace(leftCid, speciesNode, leftGeneNode, c, scenario, stochastic);
-    // dest species
+    // receiving species
     scenario.setLastEventType(ReconciliationEventType::EVENT_T);
     ok &= backtrace(rightCid, recCell.event.pllDestSpeciesNode, rightGeneNode,
                     c, scenario, stochastic);
     break;
+  case ReconciliationEventType::EVENT_SL:
+    scenario.setLastEventType(recCell.event.type);
+    ok &= backtrace(cid, recCell.event.pllDestSpeciesNode, geneNode, c,
+                    scenario, stochastic);
+    break;
+  case ReconciliationEventType::EVENT_DL:
+    // the gene got duplicated, but one copy was lost, we resample again
+    ok &= backtrace(cid, speciesNode, geneNode, c, scenario, stochastic);
+    break;
   case ReconciliationEventType::EVENT_TL:
     if (recCell.event.pllDestSpeciesNode == nullptr) {
-      // the gene was lost in the recieving species, we resample again
-      scenario.setLastEventType(ReconciliationEventType::EVENT_S);
+      // the gene was lost in the receiving species, we resample again
       ok &= backtrace(cid, speciesNode, geneNode, c, scenario, stochastic);
     } else {
       scenario.setLastEventType(ReconciliationEventType::EVENT_TL);
@@ -356,9 +482,10 @@ bool MultiModelTemplate<REAL>::backtrace(unsigned int cid,
     }
     break;
   case ReconciliationEventType::EVENT_None:
-    label = _ccp.getCidToLeaves().at(cid);
-    geneNode->label = new char[label.size() + 1];
-    memcpy(geneNode->label, label.c_str(), label.size() + 1);
+    // on leaf speciation
+    geneLabel = recCell.event.label;
+    geneNode->label = new char[geneLabel.size() + 1];
+    memcpy(geneNode->label, geneLabel.c_str(), geneLabel.size() + 1);
     break;
   default:
     ok = false;

--- a/src/ale/OptimizationClasses.cpp
+++ b/src/ale/OptimizationClasses.cpp
@@ -2,10 +2,11 @@
 
 #include <fstream>
 #include <map>
-#include <parallelization/ParallelContext.hpp>
 #include <sstream>
-#include <trees/PLLRootedTree.hpp>
 #include <unordered_set>
+
+#include <parallelization/ParallelContext.hpp>
+#include <trees/PLLRootedTree.hpp>
 #include <util/RecModelInfo.hpp>
 
 static void extractSpeciesToCatRecursive(

--- a/src/ale/OptimizationClasses.hpp
+++ b/src/ale/OptimizationClasses.hpp
@@ -1,10 +1,11 @@
 #pragma once
 
-#include <maths/Parameters.hpp>
 #include <string>
 #include <unordered_map>
-#include <util/enums.hpp>
 #include <vector>
+
+#include <maths/Parameters.hpp>
+#include <util/enums.hpp>
 
 class PLLRootedTree;
 struct RecModelInfo;

--- a/src/ale/TrimFamilies.cpp
+++ b/src/ale/TrimFamilies.cpp
@@ -1,12 +1,13 @@
 #include "TrimFamilies.hpp"
 
+#include <algorithm>
+#include <vector>
+
 #include <IO/GeneSpeciesMapping.hpp>
 #include <IO/Logger.hpp>
-#include <algorithm>
 #include <ccp/ConditionalClades.hpp>
 #include <parallelization/ParallelContext.hpp>
 #include <util/types.hpp>
-#include <vector>
 
 void TrimFamilies::trimMinSpeciesCoverage(Families &families,
                                           unsigned int minCoverage) {

--- a/src/ale/UndatedDLMultiModel.hpp
+++ b/src/ale/UndatedDLMultiModel.hpp
@@ -1,16 +1,13 @@
 #pragma once
 
 #include "MultiModel.hpp"
-#include <IO/GeneSpeciesMapping.hpp>
-#include <ccp/ConditionalClades.hpp>
-#include <maths/ScaledValue.hpp>
-#include <trees/PLLRootedTree.hpp>
 
-class RecModelInfo;
-double log(ScaledValue v);
-
-template <class REAL>
-class UndatedDLMultiModel : public MultiModelTemplate<REAL> {
+/**
+ *  Implements all HGT modelling-dependent functions of
+ *  the MultiModel class in the context of the UndatedDL
+ *  model
+ */
+template <class REAL> class UndatedDLMultiModel : public MultiModel<REAL> {
 public:
   UndatedDLMultiModel(PLLRootedTree &speciesTree,
                       const GeneSpeciesMapping &geneSpeciesMapping,
@@ -18,191 +15,322 @@ public:
 
   virtual ~UndatedDLMultiModel() {}
 
-  virtual void setRates(const RatesVector &);
-  virtual double computeLogLikelihood();
-  virtual corax_rnode_t *sampleSpeciesNode(unsigned int &category);
+  virtual void setAlpha(double alpha);
+  virtual void setRates(const RatesVector &rates);
 
 private:
+  unsigned int _gammaCatNumber;
+  std::vector<double> _gammaScalers;
+  RatesVector _dlRates;
   std::vector<double> _PD; // Duplication probability, per species branch
   std::vector<double> _PL; // Loss probability, per species branch
   std::vector<double> _PS; // Speciation probability, per species branch
   std::vector<double> _OP; // Origination probability, per species branch
-  std::vector<double> _uE; // Extinction probability, per species branch
+  std::vector<REAL> _uE;   // Extinction probability, per species branch
   OriginationStrategy _originationStrategy;
-  using DLCLV = std::vector<REAL>;
-  std::vector<DLCLV> _dlclvs;
-  RatesVector _dlRates;
 
-  REAL getLikelihoodFactor();
+  // Element e of the gene clade's DLCLV stores the probability of the clade,
+  // given the clade is mapped to the species branch e.
+  // In the paper: Pi_{e,gamma} of a clade gamma for each branch e
+  using DLCLV = std::vector<REAL>;
+  // vector of DLCLVs for all observed clades
+  std::vector<DLCLV> _dlclvs;
+
+  // functions to work with CLVs
+  virtual void allocateMemory();
+  virtual void deallocateMemory();
+  virtual void updateCLV(CID cid);
+
+  // functions to work with probabilities
   virtual void recomputeSpeciesProbabilities();
+  virtual double getLikelihoodFactor(unsigned int category);
+  virtual REAL getRootCladeLikelihood(corax_rnode_t *speciesNode,
+                                      unsigned int category);
   virtual bool computeProbability(CID cid, corax_rnode_t *speciesNode,
-                                  size_t category, REAL &proba,
+                                  unsigned int category, REAL &proba,
                                   ReconciliationCell<REAL> *recCell = nullptr);
+
+  // functions to work with _llCache
+  virtual size_t getHash() { return this->getSpeciesTreeHash(); }
 };
 
+/**
+ *  Constructor
+ */
 template <class REAL>
 UndatedDLMultiModel<REAL>::UndatedDLMultiModel(
     PLLRootedTree &speciesTree, const GeneSpeciesMapping &geneSpeciesMapping,
     const RecModelInfo &info, const std::string &ccpFile)
-    : MultiModelTemplate<REAL>(speciesTree, geneSpeciesMapping, info, ccpFile),
-      _PD(this->getAllSpeciesNodeNumber(), 0.2),
-      _PL(this->getAllSpeciesNodeNumber(), 0.2),
-      _PS(this->getAllSpeciesNodeNumber(), 1.0),
+    : MultiModel<REAL>(speciesTree, geneSpeciesMapping, info, ccpFile),
+      _gammaCatNumber(info.gammaCategories),
+      _gammaScalers(_gammaCatNumber, 1.0),
+      _PD(this->getAllSpeciesNodeNumber() * _gammaCatNumber, 0.2),
+      _PL(this->getAllSpeciesNodeNumber() * _gammaCatNumber, 0.2),
+      _PS(this->getAllSpeciesNodeNumber() * _gammaCatNumber, 1.0),
       _OP(this->getAllSpeciesNodeNumber(),
           1.0 / static_cast<double>(this->getAllSpeciesNodeNumber())),
-      _uE(this->getAllSpeciesNodeNumber(), 0.0),
+      _uE(this->getAllSpeciesNodeNumber() * _gammaCatNumber, REAL()),
       _originationStrategy(info.originationStrategy) {
-  std::vector<REAL> zeros(this->getAllSpeciesNodeNumber(), REAL());
-  _dlclvs = std::vector<std::vector<REAL>>(this->_ccp.getCladesNumber(), zeros);
-  for (unsigned int e = 0; e < this->_speciesTree.getNodeNumber(); ++e) {
-    double sum = _PD[e] + _PL[e] + _PS[e];
-    _PD[e] /= sum;
-    _PL[e] /= sum;
-    _PS[e] /= sum;
+  auto N = this->getAllSpeciesNodeNumber();
+  // set gamma scalers with the default alpha
+  setAlpha(1.0);
+  // set all DLO rates to the default value
+  _dlRates.resize(this->_info.modelFreeParameters(),
+                  std::vector<double>(N, 0.2));
+  // initialize DLCLVs if needed
+  if (!this->_memorySavings) {
+    allocateMemory();
   }
-  this->onSpeciesTreeChange(nullptr);
+}
+
+template <class REAL> void UndatedDLMultiModel<REAL>::setAlpha(double alpha) {
+  corax_compute_gamma_cats(alpha, _gammaScalers.size(), &_gammaScalers[0],
+                           CORAX_GAMMA_RATES_MEAN);
+  this->invalidateAllSpeciesNodes();
+  this->resetCache();
 }
 
 template <class REAL>
 void UndatedDLMultiModel<REAL>::setRates(const RatesVector &rates) {
   assert(rates.size() == this->_info.modelFreeParameters());
   _dlRates = rates;
-  recomputeSpeciesProbabilities();
+  this->invalidateAllSpeciesNodes();
+  this->resetCache();
 }
 
-template <class REAL> double UndatedDLMultiModel<REAL>::computeLogLikelihood() {
-  if (this->_ccp.skip()) {
-    return 0.0;
-  }
-  this->beforeComputeLogLikelihood();
-  std::vector<REAL> zeros(this->_speciesTree.getNodeNumber(), REAL());
-  _dlclvs = std::vector<std::vector<REAL>>(this->_ccp.getCladesNumber(), zeros);
-  for (CID cid = 0; cid < this->_ccp.getCladesNumber(); ++cid) {
+/**
+ *  Allocate memory to the CLVs
+ */
+template <class REAL> void UndatedDLMultiModel<REAL>::allocateMemory() {
+  DLCLV nullCLV(this->getAllSpeciesNodeNumber() * _gammaCatNumber, REAL());
+  _dlclvs = std::vector<DLCLV>(this->_ccp.getCladesNumber(), nullCLV);
+}
+
+/**
+ *  Free memory allocated to the CLVs
+ */
+template <class REAL> void UndatedDLMultiModel<REAL>::deallocateMemory() {
+  _dlclvs = std::vector<DLCLV>();
+}
+
+/**
+ *  Compute the CLV for a given clade
+ */
+template <class REAL> void UndatedDLMultiModel<REAL>::updateCLV(CID cid) {
+  auto &uq = _dlclvs[cid];
+  std::fill(uq.begin(), uq.end(), REAL());
+  bool ok;
+  for (unsigned int c = 0; c < _gammaCatNumber; ++c) {
+    // postorder species tree traversal is granted
     for (auto speciesNode : this->getPrunedSpeciesNodes()) {
-      auto category = 0;
-      computeProbability(cid, speciesNode, category,
-                         _dlclvs[cid][speciesNode->node_index]);
+      auto e = speciesNode->node_index;
+      auto ec = e * _gammaCatNumber + c;
+      REAL p = REAL();
+      ok = computeProbability(cid, speciesNode, c, p);
+      assert(ok);
+      uq[ec] = p;
     }
   }
-  auto rootCID = this->_ccp.getCladesNumber() - 1;
-  REAL res = REAL();
-  for (auto speciesNode : this->getPrunedSpeciesNodes()) {
-    auto e = speciesNode->node_index;
-    res += _dlclvs[rootCID][e] * _OP[e];
-  }
-  // the root correction makes sure that UndatedDLMultiModel and
-  // UndatedDL model are equivalent when there is one tree per
-  // family: the UndatedDLMultiModel integrates over all possible
-  // roots and adds a 1/numberOfGeneRoots weight that is not
-  // present un the UndatedDL, so we multiply back here
-  auto rootCorrection = double(this->_ccp.getLeafNumber() * 2 - 3);
-  return log(res) - log(getLikelihoodFactor()) + log(rootCorrection);
 }
 
+/**
+ *  Compute the per species branch probabilities of
+ *  the elementary events of clade evolution
+ */
 template <class REAL>
 void UndatedDLMultiModel<REAL>::recomputeSpeciesProbabilities() {
+  auto allSpeciesNumber = this->getAllSpeciesNodeNumber();
+  // recompute _PD, _PL, _PS
   auto &dupRates = _dlRates[0];
   auto &lossRates = _dlRates[1];
-  assert(this->getAllSpeciesNodeNumber() == dupRates.size());
-  assert(this->getAllSpeciesNodeNumber() == lossRates.size());
-  _PD = dupRates;
-  _PL = lossRates;
-  _PS.resize(this->getAllSpeciesNodeNumber());
-  for (auto node : this->getPrunedSpeciesNodes()) {
-    auto e = node->node_index;
-    if (this->_info.noDup) {
-      _PD[e] = 0.0;
+  assert(allSpeciesNumber == dupRates.size());
+  assert(allSpeciesNumber == lossRates.size());
+  std::fill(_PD.begin(), _PD.end(), 0.0);
+  std::fill(_PL.begin(), _PL.end(), 0.0);
+  std::fill(_PS.begin(), _PS.end(), 0.0);
+  for (unsigned int c = 0; c < _gammaCatNumber; ++c) {
+    for (auto speciesNode : this->getPrunedSpeciesNodes()) {
+      auto e = speciesNode->node_index;
+      auto ec = e * _gammaCatNumber + c;
+      _PD[ec] = dupRates[e];
+      _PL[ec] = lossRates[e];
+      _PS[ec] = _gammaScalers[c];
+      if (this->_info.noDup) {
+        _PD[ec] = 0.0;
+      }
+      auto sum = _PD[ec] + _PL[ec] + _PS[ec];
+      _PD[ec] /= sum;
+      _PL[ec] /= sum;
+      _PS[ec] /= sum;
     }
-    auto sum = _PD[e] + _PL[e] + 1.0;
-    _PD[e] /= sum;
-    _PL[e] /= sum;
-    _PS[e] = 1.0 / sum;
   }
+  // recompute _OP
   std::vector<corax_rnode_t *> speciesNodesBuffer;
-  std::vector<corax_rnode_t *> *possibleSpeciesRootNodes = nullptr;
+  std::vector<corax_rnode_t *> *possibleOriginationSpeciesNodes = nullptr;
   switch (_originationStrategy) {
   case OriginationStrategy::UNIFORM:
   case OriginationStrategy::OPTIMIZE:
-    possibleSpeciesRootNodes = &(this->getPrunedSpeciesNodes());
+    possibleOriginationSpeciesNodes = &(this->getPrunedSpeciesNodes());
     break;
   case OriginationStrategy::ROOT:
     speciesNodesBuffer.push_back(this->_speciesTree.getRoot());
-    possibleSpeciesRootNodes = &speciesNodesBuffer;
+    possibleOriginationSpeciesNodes = &speciesNodesBuffer;
     break;
   case OriginationStrategy::LCA:
-    speciesNodesBuffer.push_back(this->getSpeciesLCA());
-    possibleSpeciesRootNodes = &speciesNodesBuffer;
+    speciesNodesBuffer.push_back(this->getCoveredSpeciesLCA());
+    possibleOriginationSpeciesNodes = &speciesNodesBuffer;
     break;
   }
+  std::fill(_OP.begin(), _OP.end(), 0.0);
   if (_originationStrategy == OriginationStrategy::OPTIMIZE) {
+    auto &oriRates = _dlRates[2];
+    assert(allSpeciesNumber == oriRates.size());
     double sum = 0.0;
-    for (auto speciesNode : *possibleSpeciesRootNodes) {
-      sum += _dlRates[2][speciesNode->node_index];
+    for (auto speciesNode : *possibleOriginationSpeciesNodes) {
+      auto e = speciesNode->node_index;
+      sum += oriRates[e];
     }
-    sum /= static_cast<double>(this->getPrunedSpeciesNodes().size());
-    for (auto speciesNode : *possibleSpeciesRootNodes) {
-      _OP[speciesNode->node_index] = _dlRates[2][speciesNode->node_index] / sum;
+    for (auto speciesNode : *possibleOriginationSpeciesNodes) {
+      auto e = speciesNode->node_index;
+      _OP[e] = oriRates[e] / sum;
     }
   } else {
-    std::fill(_OP.begin(), _OP.end(), 0.0);
-    for (auto speciesNode : *possibleSpeciesRootNodes) {
-      _OP[speciesNode->node_index] = 1.0;
+    double sum = static_cast<double>(possibleOriginationSpeciesNodes->size());
+    for (auto speciesNode : *possibleOriginationSpeciesNodes) {
+      auto e = speciesNode->node_index;
+      _OP[e] = 1.0 / sum;
     }
   }
-  for (auto speciesNode : this->getPrunedSpeciesNodes()) {
-    auto e = speciesNode->node_index;
-    double a = _PD[e];
-    double b = -1.0;
-    double c = _PL[e];
-    if (this->getSpeciesLeft(speciesNode)) {
-      c += _PS[e] * _uE[this->getSpeciesLeft(speciesNode)->node_index] *
-           _uE[this->getSpeciesRight(speciesNode)->node_index];
+  // recompute _uE
+  std::fill(_uE.begin(), _uE.end(), REAL());
+  // iterate several times to resolve _uE probas with
+  // fixed point optimization
+  unsigned int maxIt = 4;
+  for (unsigned int it = 0; it < maxIt; ++it) {
+    for (unsigned int c = 0; c < _gammaCatNumber; ++c) {
+      // postorder species tree traversal is granted
+      for (auto speciesNode : this->getPrunedSpeciesNodes()) {
+        auto e = speciesNode->node_index;
+        auto ec = e * _gammaCatNumber + c;
+        REAL temp;
+        REAL proba = REAL();
+        // L scenario
+        temp = REAL(_PL[ec]);
+        scale(temp);
+        proba += temp;
+        // S scenario
+        if (this->getSpeciesLeft(speciesNode)) {
+          // internal branch
+          auto f = this->getSpeciesLeft(speciesNode)->node_index;
+          auto g = this->getSpeciesRight(speciesNode)->node_index;
+          auto fc = f * _gammaCatNumber + c;
+          auto gc = g * _gammaCatNumber + c;
+          temp = _uE[fc] * (_uE[gc] * _PS[ec]); // SEE scenario
+        } else {
+          // terminal branch
+          temp = REAL(_PS[ec] * this->_fm[e]); // S but not observed scenario
+        }
+        scale(temp);
+        proba += temp;
+        // DEE scenario
+        temp = _uE[ec] * (_uE[ec] * _PD[ec]);
+        scale(temp);
+        proba += temp;
+        assert(proba < REAL(1.000001));
+        _uE[ec] = proba;
+      }
     }
-    double proba = solveSecondDegreePolynome(a, b, c);
-    assert(proba >= 0.0 && proba <= 1.0);
-    _uE[speciesNode->node_index] = proba;
-  }
+  } // end of iteration
 }
 
+/**
+ *  Correction factor to the species tree likelihood,
+ *  because we condition on survival
+ */
+template <class REAL>
+double UndatedDLMultiModel<REAL>::getLikelihoodFactor(unsigned int category) {
+  double factor(0.0);
+  auto c = category;
+  for (auto speciesNode : this->getPrunedSpeciesNodes()) {
+    auto e = speciesNode->node_index;
+    auto ec = e * _gammaCatNumber + c;
+    factor += (1.0 - _uE[ec]) * _OP[e];
+  }
+  return factor;
+}
+
+/**
+ *  Probability of the current family to evolve starting
+ *  from a given species branch
+ */
+template <class REAL>
+REAL UndatedDLMultiModel<REAL>::getRootCladeLikelihood(
+    corax_rnode_t *speciesNode, unsigned int category) {
+  auto rootCID = this->_ccp.getCladesNumber() - 1;
+  auto c = category;
+  auto e = speciesNode->node_index;
+  auto ec = e * _gammaCatNumber + c;
+  REAL likelihood = _dlclvs[rootCID][ec] * _OP[e];
+  scale(likelihood);
+  return likelihood;
+}
+
+/**
+ *  Compute the CLV value for a given cid (clade id) and a given
+ *  species node and write it to the proba variable
+ */
 template <class REAL>
 bool UndatedDLMultiModel<REAL>::computeProbability(
-    CID cid, corax_rnode_t *speciesNode, size_t, REAL &proba,
+    CID cid, corax_rnode_t *speciesNode, unsigned int category, REAL &proba,
     ReconciliationCell<REAL> *recCell) {
   proba = REAL();
+  REAL temp;
+  bool isGeneLeaf = this->_ccp.isLeaf(cid);
   bool isSpeciesLeaf = !this->getSpeciesLeft(speciesNode);
+  auto c = category;
   auto e = speciesNode->node_index;
+  auto ec = e * _gammaCatNumber + c;
+  unsigned int f = 0;
+  unsigned int g = 0;
+  unsigned int fc = 0;
+  unsigned int gc = 0;
+  if (!isSpeciesLeaf) {
+    f = this->getSpeciesLeft(speciesNode)->node_index;
+    g = this->getSpeciesRight(speciesNode)->node_index;
+    fc = f * _gammaCatNumber + c;
+    gc = g * _gammaCatNumber + c;
+  }
   REAL maxProba = REAL();
   if (recCell) {
     recCell->event.geneNode = cid;
     recCell->event.speciesNode = e;
-    recCell->event.type = ReconciliationEventType::EVENT_None;
     maxProba = recCell->maxProba;
   }
-  // terminal gene and species nodes
-  if (this->_ccp.isLeaf(cid) && isSpeciesLeaf) {
-    if (this->_geneToSpecies[cid] == e) {
-      proba = REAL(_PS[e]);
-      if (recCell) {
+  // S events on terminal species branches can happen
+  // for terminal gene nodes only:
+  if (isGeneLeaf) {
+    // - S event on a terminal species branch (only for compatible genes and
+    // species)
+    if (isSpeciesLeaf && this->_geneToSpecies[cid] == e) {
+      temp = REAL(_PS[ec]);
+      scale(temp);
+      proba += temp;
+      if (recCell && proba > maxProba) {
+        recCell->event.type = ReconciliationEventType::EVENT_None;
         recCell->event.label = this->_ccp.getLeafLabel(cid);
+        return true;
       }
     }
-    return true;
   }
-  REAL temp;
-  unsigned int f = 0;
-  unsigned int g = 0;
-  if (!isSpeciesLeaf) {
-    f = this->getSpeciesLeft(speciesNode)->node_index;
-    g = this->getSpeciesRight(speciesNode)->node_index;
-  }
-
+  // S events on internal species branches and D events can happen
+  // for ancestral gene nodes only:
   for (const auto &cladeSplit : this->_ccp.getCladeSplits(cid)) {
     auto cidLeft = cladeSplit.left;
     auto cidRight = cladeSplit.right;
     auto freq = cladeSplit.frequency;
-    if (not isSpeciesLeaf) {
-      // S event;
-      temp = _dlclvs[cidLeft][f] * _dlclvs[cidRight][g] * (_PS[e] * freq);
+    // - S event on an internal species branch
+    if (!isSpeciesLeaf) {
+      temp = _dlclvs[cidLeft][fc] * _dlclvs[cidRight][gc] * (_PS[ec] * freq);
       scale(temp);
       proba += temp;
       if (recCell && proba > maxProba) {
@@ -213,20 +341,20 @@ bool UndatedDLMultiModel<REAL>::computeProbability(
         recCell->blRight = cladeSplit.blRight;
         return true;
       }
-      temp = _dlclvs[cidRight][f] * _dlclvs[cidLeft][g] * (_PS[e] * freq);
+      temp = _dlclvs[cidRight][fc] * _dlclvs[cidLeft][gc] * (_PS[ec] * freq);
       scale(temp);
       proba += temp;
       if (recCell && proba > maxProba) {
         recCell->event.type = ReconciliationEventType::EVENT_S;
         recCell->event.leftGeneIndex = cidRight;
         recCell->event.rightGeneIndex = cidLeft;
-        recCell->blLeft = cladeSplit.blLeft;
-        recCell->blRight = cladeSplit.blRight;
+        recCell->blLeft = cladeSplit.blRight;
+        recCell->blRight = cladeSplit.blLeft;
         return true;
       }
     }
-    // D events
-    temp = _dlclvs[cidLeft][e] * _dlclvs[cidRight][e] * (_PD[e] * freq);
+    // - D event
+    temp = _dlclvs[cidLeft][ec] * _dlclvs[cidRight][ec] * (_PD[ec] * freq);
     scale(temp);
     proba += temp;
     if (recCell && proba > maxProba) {
@@ -238,64 +366,50 @@ bool UndatedDLMultiModel<REAL>::computeProbability(
       return true;
     }
   }
-  if (not isSpeciesLeaf) {
-    // SL event
-    temp = _dlclvs[cid][f] * (_uE[g] * _PS[e]);
+  // SL events and DL events can happen
+  // for any of gene nodes:
+  // - SL event (only on an internal species branch)
+  if (!isSpeciesLeaf) {
+    temp = _dlclvs[cid][fc] * (_uE[gc] * _PS[ec]);
     scale(temp);
     proba += temp;
     if (recCell && proba > maxProba) {
       recCell->event.type = ReconciliationEventType::EVENT_SL;
-      recCell->event.destSpeciesNode = f;
+      recCell->event.lostSpeciesNode = g;
       recCell->event.pllDestSpeciesNode = this->getSpeciesLeft(speciesNode);
       recCell->event.pllLostSpeciesNode = this->getSpeciesRight(speciesNode);
       return true;
     }
-
-    temp = _dlclvs[cid][g] * (_uE[f] * _PS[e]);
+    temp = _dlclvs[cid][gc] * (_uE[fc] * _PS[ec]);
     scale(temp);
     proba += temp;
     if (recCell && proba > maxProba) {
       recCell->event.type = ReconciliationEventType::EVENT_SL;
-      recCell->event.destSpeciesNode = g;
+      recCell->event.lostSpeciesNode = f;
       recCell->event.pllDestSpeciesNode = this->getSpeciesRight(speciesNode);
       recCell->event.pllLostSpeciesNode = this->getSpeciesLeft(speciesNode);
       return true;
     }
   }
-  // DL event
-  // proba /= (1.0 - 2.0 * _PD[e] * _uE[e]);
-  if (recCell) {
-    // std::cerr << "cerr " << proba << " " << maxProba << " " << (proba >
-    // maxProba) << std::endl;
-    return false; // we haven't sampled any event
-  }
-  return true;
-}
-
-template <class REAL> REAL UndatedDLMultiModel<REAL>::getLikelihoodFactor() {
-  REAL factor(0.0);
-  for (auto speciesNode : this->getPrunedSpeciesNodes()) {
-    auto e = speciesNode->node_index;
-    factor += (REAL(1.0) - REAL(_uE[e]));
-  }
-  return factor;
-}
-
-template <class REAL>
-corax_rnode_t *
-UndatedDLMultiModel<REAL>::sampleSpeciesNode(unsigned int &category) {
-  category = 0;
-  auto rootCID = this->_ccp.getCladesNumber() - 1;
-  auto &uq = _dlclvs[rootCID];
-  auto totalLL = std::accumulate(uq.begin(), uq.end(), REAL());
-  REAL toSample = totalLL * Random::getProba();
-  REAL sumLL = REAL();
-  for (auto speciesNode : this->getPrunedSpeciesNodes()) {
-    sumLL += uq[speciesNode->node_index];
-    if (sumLL > toSample) {
-      return speciesNode;
+  if (!this->_info.noDL) {
+    // - DL event
+    temp = proba / (1.0 - (_uE[ec] * _PD[ec] * 2.0));
+    scale(temp);
+    proba = temp;
+    if (recCell && proba > maxProba) {
+      // in fact, nothing happens, we'll have to resample
+      recCell->event.type = ReconciliationEventType::EVENT_DL;
+      return true;
     }
   }
-  assert(false);
-  return nullptr;
+  if (recCell) {
+    Logger::error << "error: proba=" << proba << ", maxProba=" << maxProba
+                  << " (proba < maxProba)" << std::endl;
+    return false; // we haven't sampled any event, this should not happen
+  }
+  if (proba > REAL(1.0)) {
+    Logger::error << "error: proba=" << proba << " (proba > 1)" << std::endl;
+    return false;
+  }
+  return true;
 }

--- a/src/ale/UndatedDTLMultiModel.hpp
+++ b/src/ale/UndatedDTLMultiModel.hpp
@@ -1,23 +1,23 @@
 #pragma once
 
-#include "MultiModel.hpp"
-#include <IO/GeneSpeciesMapping.hpp>
-#include <ccp/ConditionalClades.hpp>
-#include <maths/ScaledValue.hpp>
 #include <trees/DatedTree.hpp>
-#include <trees/PLLRootedTree.hpp>
 
-class RecModelInfo;
-double log(ScaledValue v);
+#include "MultiModel.hpp"
 
+/**
+ *  Highway with the proba scaled per rate category
+ */
 struct WeightedHighway {
   Highway highway;
-  double proba;
+  std::vector<double> proba;
 };
 
-template <class REAL>
-class UndatedDTLMultiModel : public MultiModelTemplate<REAL> {
-
+/**
+ *  Implements all HGT modelling-dependent functions of
+ *  the MultiModel class in the context of the UndatedDTL
+ *  model
+ */
+template <class REAL> class UndatedDTLMultiModel : public MultiModel<REAL> {
 public:
   UndatedDTLMultiModel(DatedTree &speciesTree,
                        const GeneSpeciesMapping &geneSpeciesMapping,
@@ -25,419 +25,288 @@ public:
 
   virtual ~UndatedDTLMultiModel() {}
 
-  virtual void setRates(const RatesVector &);
   virtual void setAlpha(double alpha);
-  virtual double computeLogLikelihood();
-  virtual corax_rnode_t *sampleSpeciesNode(unsigned int &category);
-  virtual void setHighways(const std::vector<Highway> &highways) {
-    for (auto &speciesWeightedHighways : _highways) {
-      speciesWeightedHighways.clear();
-    }
-    for (auto highway : highways) {
-      WeightedHighway hp;
-      hp.highway = highway;
-      // map the highway to the pruned species tree
-      if (this->prunedMode()) {
-        hp.highway.src = this->_speciesToPrunedNode[highway.src->node_index];
-        hp.highway.dest = this->_speciesToPrunedNode[highway.dest->node_index];
-      } else {
-        hp.highway.src = highway.src;
-        hp.highway.dest = highway.dest;
-      }
-      if (/*!_speciesToPrunedNode[highway.dest->node_index] ||*/ !hp.highway
-              .src ||
-          !hp.highway.dest) {
-        // this highway should not affect this family
-        continue;
-      }
-      hp.proba = highway.proba; // this value will be normalized later on
-      if (hp.highway.src != hp.highway.dest) {
-        // do not count transfers to self
-        _highways[hp.highway.src->node_index].push_back(hp);
-      }
-    }
-    resetCache();
-    recomputeSpeciesProbabilities();
-  }
-
-  virtual void onSpeciesTreeChange(
-      const std::unordered_set<corax_rnode_t *> *nodesToInvalidate) {
-    MultiModel::onSpeciesTreeChange(nodesToInvalidate);
-    resetCache();
-  }
-
-protected:
-  virtual void updateCLVs();
-  virtual void allocateMemory();
-  virtual void deallocateMemory();
+  virtual void setRates(const RatesVector &rates);
+  virtual void setHighways(const std::vector<Highway> &highways);
 
 private:
-  REAL getTransferSum(unsigned int cid, unsigned int e, unsigned int c);
-
   DatedTree &_datedTree;
-  size_t _gammaCatNumber;
+  unsigned int _gammaCatNumber;
   std::vector<double> _gammaScalers;
   RatesVector _dtlRates;
+  std::vector<std::vector<WeightedHighway>>
+      _highways;           // Highways, per species branch
   std::vector<double> _PD; // Duplication probability, per species branch
   std::vector<double> _PL; // Loss probability, per species branch
   std::vector<double> _PT; // Transfer probability, per species branch
   std::vector<double> _PS; // Speciation probability, per species branch
   std::vector<double> _OP; // Origination probability, per species branch
   std::vector<REAL> _uE;   // Extinction probability, per species branch
-  std::vector<REAL> _uEBar;
-  std::unordered_map<size_t, double> _llCache;
-  std::vector<std::vector<WeightedHighway>> _highways;
-  TransferConstaint _transferConstraint;
+  std::vector<REAL> _tE; // Transfer-extinction probability, per species branch
   OriginationStrategy _originationStrategy;
-  /**
-   *  All intermediate results needed to compute the reconciliation likelihood
-   *  each gene node has one DTLCLV object
-   *  Each DTLCLV gene  object is a function of the DTLCLVs of the direct
-   * children genes
-   */
+  TransferConstaint _transferConstraint;
+  // Allowed transfers, per species branch
+  std::vector<std::vector<corax_rnode_t *>> _transferCandidateSpeciesNodes;
+
   struct DTLCLV {
-    DTLCLV() : _survivingTransferSum(REAL()) {}
-
-    DTLCLV(size_t speciesNumber, size_t gammaCategories)
-        : _uq(speciesNumber * gammaCategories, REAL()),
-          _correctionSum(speciesNumber * gammaCategories, REAL()),
-          _correctionNorm(speciesNumber * gammaCategories, 0.0),
-          _survivingTransferSum(gammaCategories, REAL()) {}
-    // probability of a gene node rooted at a species node
+    // Element e of the gene clade's _uq stores the probability of the clade,
+    // given the clade is mapped to the species branch e.
+    // In the paper: Pi_{e,gamma} of a clade gamma for each branch e
     std::vector<REAL> _uq;
-    std::vector<REAL> _correctionSum;
-    std::vector<double> _correctionNorm;
-
-    // sum of transfer probabilities. Can be computed only once
-    // for all species, to reduce computation complexity
-    // (each entry corresponds to one category)
-    std::vector<REAL> _survivingTransferSum;
+    // Element e of the gene clade's _ut stores the probability of the clade
+    // to be transferred from the species node e to some other species node.
+    // In the paper: \bar{Pi}_{e,gamma} of a clade gamma for each branch e
+    std::vector<REAL> _tq;
+    DTLCLV() : _uq(0), _tq(0) {}
+    DTLCLV(unsigned int speciesNumber, unsigned int gammaCategories)
+        : _uq(speciesNumber * gammaCategories, REAL()),
+          _tq(speciesNumber * gammaCategories, REAL()) {}
   };
-
+  // vector of DTLCLVs for all observed clades
   std::vector<DTLCLV> _dtlclvs;
 
-  void updateCLV(CID cid);
-  double getLikelihoodFactor(unsigned int category);
-  virtual void recomputeSpeciesProbabilities();
-  virtual bool computeProbability(CID cid, corax_rnode_t *speciesNode,
-                                  size_t category, REAL &proba,
-                                  ReconciliationCell<REAL> *recCell = nullptr);
-  bool sampleTransferEvent(unsigned int cid, corax_rnode_t *originSpeciesNode,
-                           size_t category, Scenario::Event &event);
-  size_t getHash();
-  void resetCache() { _llCache.clear(); }
+  // functions to work with CLVs
+  virtual void allocateMemory();
+  virtual void deallocateMemory();
+  virtual void updateCLV(CID cid);
 
-  double getTransferWeightNorm() const {
-    return double(this->getPrunedSpeciesNodeNumber());
+  // functions to work with probabilities
+  virtual void recomputeSpeciesProbabilities();
+  virtual double getLikelihoodFactor(unsigned int category);
+  virtual REAL getRootCladeLikelihood(corax_rnode_t *speciesNode,
+                                      unsigned int category);
+  virtual bool computeProbability(CID cid, corax_rnode_t *speciesNode,
+                                  unsigned int category, REAL &proba,
+                                  ReconciliationCell<REAL> *recCell = nullptr);
+
+  // functions to deal with transfers
+  void updateTransferCandidates();
+  bool sampleTransferEvent(CID cid, corax_rnode_t *srcSpeciesNode,
+                           unsigned int category, Scenario::Event &event);
+
+  double getTransferWeightNorm(unsigned int speciesNodeIndex) const {
+    auto e = speciesNodeIndex;
+    return static_cast<double>(_transferCandidateSpeciesNodes[e].size());
   }
+
+  // functions to work with _llCache
+  virtual size_t getHash();
 };
 
+/**
+ *  Constructor
+ */
 template <class REAL>
 UndatedDTLMultiModel<REAL>::UndatedDTLMultiModel(
     DatedTree &speciesTree, const GeneSpeciesMapping &geneSpeciesMapping,
     const RecModelInfo &info, const std::string &ccpFile)
-    : MultiModelTemplate<REAL>(speciesTree.getRootedTree(), geneSpeciesMapping,
-                               info, ccpFile),
+    : MultiModel<REAL>(speciesTree.getRootedTree(), geneSpeciesMapping, info,
+                       ccpFile),
       _datedTree(speciesTree), _gammaCatNumber(info.gammaCategories),
       _gammaScalers(_gammaCatNumber, 1.0),
-      _PD(this->_speciesTree.getNodeNumber() * _gammaCatNumber, 0.2),
-      _PL(this->_speciesTree.getNodeNumber() * _gammaCatNumber, 0.2),
-      _PT(this->_speciesTree.getNodeNumber() * _gammaCatNumber, 0.1),
-      _PS(this->_speciesTree.getNodeNumber() * _gammaCatNumber, 1.0),
-      _OP(this->_speciesTree.getNodeNumber(),
-          1.0 / static_cast<double>(this->_speciesTree.getNodeNumber())),
-      _uE(this->_speciesTree.getNodeNumber() * _gammaCatNumber, REAL()),
-      _uEBar(this->_speciesTree.getNodeNumber() * _gammaCatNumber, REAL()),
-      _transferConstraint(info.transferConstraint),
-      _originationStrategy(info.originationStrategy) {
-  auto N = this->_speciesTree.getNodeNumber();
-  _highways.resize(N);
+      _PD(this->getAllSpeciesNodeNumber() * _gammaCatNumber, 0.2),
+      _PL(this->getAllSpeciesNodeNumber() * _gammaCatNumber, 0.2),
+      _PT(this->getAllSpeciesNodeNumber() * _gammaCatNumber, 0.1),
+      _PS(this->getAllSpeciesNodeNumber() * _gammaCatNumber, 1.0),
+      _OP(this->getAllSpeciesNodeNumber(),
+          1.0 / static_cast<double>(this->getAllSpeciesNodeNumber())),
+      _uE(this->getAllSpeciesNodeNumber() * _gammaCatNumber, REAL()),
+      _tE(this->getAllSpeciesNodeNumber() * _gammaCatNumber, REAL()),
+      _originationStrategy(info.originationStrategy),
+      _transferConstraint(info.transferConstraint) {
+  auto N = this->getAllSpeciesNodeNumber();
+  // set gamma scalers with the default alpha
+  setAlpha(1.0);
+  // set all DTLO rates to the default value
   _dtlRates.resize(this->_info.modelFreeParameters(),
                    std::vector<double>(N, 0.2));
-  this->onSpeciesTreeChange(nullptr);
-  setAlpha(1.0);
+  // initialize highways and per-species transfer candidates
+  _highways.resize(N);
+  _transferCandidateSpeciesNodes.resize(N);
+  // initialize DTLCLVs if needed
   if (!this->_memorySavings) {
     allocateMemory();
   }
 }
 
-template <class REAL> void UndatedDTLMultiModel<REAL>::allocateMemory() {
-  DTLCLV nullCLV(this->_speciesTree.getNodeNumber(), _gammaCatNumber);
-  _dtlclvs = std::vector<DTLCLV>(2 * (this->_ccp.getCladesNumber()), nullCLV);
-}
-
-template <class REAL> void UndatedDTLMultiModel<REAL>::deallocateMemory() {
-  _dtlclvs.clear();
+template <class REAL> void UndatedDTLMultiModel<REAL>::setAlpha(double alpha) {
+  corax_compute_gamma_cats(alpha, _gammaScalers.size(), &_gammaScalers[0],
+                           CORAX_GAMMA_RATES_MEAN);
+  this->invalidateAllSpeciesNodes();
+  this->resetCache();
 }
 
 template <class REAL>
 void UndatedDTLMultiModel<REAL>::setRates(const RatesVector &rates) {
-  resetCache();
   assert(rates.size() == this->_info.modelFreeParameters());
   _dtlRates = rates;
-  recomputeSpeciesProbabilities();
-}
-template <class REAL> void UndatedDTLMultiModel<REAL>::setAlpha(double alpha) {
-  resetCache();
-  corax_compute_gamma_cats(alpha, _gammaScalers.size(), &_gammaScalers[0],
-                           CORAX_GAMMA_RATES_MEAN);
-  recomputeSpeciesProbabilities();
+  this->invalidateAllSpeciesNodes();
+  this->resetCache();
 }
 
-/*
- *  We fill the intermediate likelihood table (P_{e,u} in the paper) for a given
- *  gene CCP
+template <class REAL>
+void UndatedDTLMultiModel<REAL>::setHighways(
+    const std::vector<Highway> &highways) {
+  for (auto &speciesWeightedHighways : _highways) {
+    speciesWeightedHighways.clear();
+  }
+  for (auto highway : highways) {
+    WeightedHighway hp;
+    hp.highway = highway;
+    // map the highway to the pruned species tree
+    if (this->prunedMode()) {
+      hp.highway.src = this->_speciesToPrunedNode[highway.src->node_index];
+      hp.highway.dest = this->_speciesToPrunedNode[highway.dest->node_index];
+    } else {
+      hp.highway.src = highway.src;
+      hp.highway.dest = highway.dest;
+    }
+    // in the pruned mode a highway from/to a species not covered by the gene
+    // family may have the src or dest species absent or may look like a
+    // self-transfer
+    if (!hp.highway.src || !hp.highway.dest ||
+        (hp.highway.src == hp.highway.dest)) {
+      // this highway should not affect this gene family
+      continue;
+    }
+    // this value will be normalized later on, separately per category
+    hp.proba.resize(_gammaCatNumber, highway.proba);
+    // update _highways
+    _highways[hp.highway.src->node_index].push_back(hp);
+  }
+  this->invalidateAllSpeciesNodes();
+  this->resetCache();
+}
+
+/**
+ *  Allocate memory to the CLVs
+ */
+template <class REAL> void UndatedDTLMultiModel<REAL>::allocateMemory() {
+  DTLCLV nullCLV(this->getAllSpeciesNodeNumber(), _gammaCatNumber);
+  _dtlclvs = std::vector<DTLCLV>(this->_ccp.getCladesNumber(), nullCLV);
+}
+
+/**
+ *  Free memory allocated to the CLVs
+ */
+template <class REAL> void UndatedDTLMultiModel<REAL>::deallocateMemory() {
+  _dtlclvs = std::vector<DTLCLV>();
+}
+
+/**
+ *  Compute the CLV for a given clade
  */
 template <class REAL> void UndatedDTLMultiModel<REAL>::updateCLV(CID cid) {
-  auto &clv = _dtlclvs[cid];
-  auto &uq = clv._uq;
-  auto &correctionSum = clv._correctionSum;
-  auto &correctionNorm = clv._correctionNorm;
-
+  auto &uq = _dtlclvs[cid]._uq;
+  auto &tq = _dtlclvs[cid]._tq;
   std::fill(uq.begin(), uq.end(), REAL());
-  auto tempUq = uq;
-  auto N = this->getPrunedSpeciesNodeNumber();
+  std::fill(tq.begin(), tq.end(), REAL());
+  // iterate several times to resolve the DL and TL terms with
+  // fixed point optimization: not needed if we don't model TL
   unsigned int maxIt = this->_info.noTL ? 1 : 4;
-  std::fill(correctionSum.begin(), correctionSum.end(), REAL());
-  std::fill(correctionNorm.begin(), correctionNorm.end(), N);
-
-  if (_transferConstraint == TransferConstaint::PARENTS) {
-    auto postOrder = this->_speciesTree.getPostOrderNodes();
-    for (auto it = postOrder.rbegin(); it != postOrder.rend(); ++it) {
-      auto speciesNode = *it;
-      auto e = speciesNode->node_index;
-      for (size_t c = 0; c < _gammaCatNumber; ++c) {
-        auto parent = speciesNode;
-        auto ec = e * _gammaCatNumber + c;
-        while (parent) {
-          correctionNorm[ec] -= 1.0;
-          auto p = parent->node_index;
-          parent = parent->parent;
-        }
-      }
-    }
-  }
-  std::fill(clv._survivingTransferSum.begin(), clv._survivingTransferSum.end(),
-            REAL());
-  // iterate several times to resolve the TL term with
-  // fixed point optimizaiton
   for (unsigned int it = 0; it < maxIt; ++it) {
-    std::vector<REAL> sums(_gammaCatNumber, REAL());
-    for (auto speciesNode : this->getPrunedSpeciesNodes()) {
-      auto e = speciesNode->node_index;
-      for (size_t c = 0; c < _gammaCatNumber; ++c) {
-        auto ec = e * _gammaCatNumber + c;
-        REAL v = REAL();
-        computeProbability(cid, speciesNode, c, v);
-        tempUq[ec] = v;
-        scale(v);
-        sums[c] += v;
-      }
-    }
-    std::swap(tempUq, uq);
-    std::fill(correctionSum.begin(), correctionSum.end(), REAL());
-    std::fill(clv._survivingTransferSum.begin(),
-              clv._survivingTransferSum.end(), REAL());
-    // precompute ancestral correction sum
-    // (to forbid transfers to parents)
-    if (_transferConstraint == TransferConstaint::PARENTS) {
-      auto postOrder = this->_speciesTree.getPostOrderNodes();
-      for (auto it = postOrder.rbegin(); it != postOrder.rend(); ++it) {
-        auto speciesNode = *it;
+    bool ok;
+    for (unsigned int c = 0; c < _gammaCatNumber; ++c) {
+      // postorder species tree traversal is granted
+      for (auto speciesNode : this->getPrunedSpeciesNodes()) {
         auto e = speciesNode->node_index;
-        for (size_t c = 0; c < _gammaCatNumber; ++c) {
-          auto parent = speciesNode;
-          auto ec = e * _gammaCatNumber + c;
-          while (parent) {
-            auto p = parent->node_index;
-            auto pc = p * _gammaCatNumber + c;
-            auto temp = uq[pc];
-            scale(temp);
-            correctionSum[ec] += temp;
-            parent = parent->parent;
-          }
-        }
+        auto ec = e * _gammaCatNumber + c;
+        REAL p = REAL();
+        ok = computeProbability(cid, speciesNode, c, p);
+        assert(ok);
+        uq[ec] = p;
       }
-    }
-    // precompute the related correction sum
-    // (to forbit transfers to older lineages)
-    if (_transferConstraint == TransferConstaint::RELDATED) {
-      std::vector<REAL> softDatedSums(N * _gammaCatNumber, REAL());
-      std::vector<REAL> softDatedSum(_gammaCatNumber, REAL());
-      for (auto leaf : this->_speciesTree.getLeaves()) {
-        auto e = leaf->node_index;
-        for (size_t c = 0; c < _gammaCatNumber; ++c) {
-          auto ec = e * _gammaCatNumber + c;
-          softDatedSum[c] += uq[ec] / getTransferWeightNorm();
+      // now that we've got the clade proba on every species branch,
+      // we can compute the clade transfer probas
+      for (auto speciesNode : this->getPrunedSpeciesNodes()) {
+        auto e = speciesNode->node_index;
+        auto ec = e * _gammaCatNumber + c;
+        REAL p = REAL();
+        for (auto destSpeciesNode : _transferCandidateSpeciesNodes[e]) {
+          auto d = destSpeciesNode->node_index;
+          auto dc = d * _gammaCatNumber + c;
+          p += uq[dc];
         }
+        p /= getTransferWeightNorm(e);
+        scale(p);
+        tq[ec] = p;
       }
-      for (auto it = _datedTree.getOrderedSpeciations().rbegin();
-           it != _datedTree.getOrderedSpeciations().rend(); ++it) {
-        auto node = (*it);
-        auto e = node->node_index;
-        for (size_t c = 0; c < _gammaCatNumber; ++c) {
-          auto ec = e * _gammaCatNumber + c;
-          softDatedSums[ec] = softDatedSum[c];
-          auto temp = uq[ec] / getTransferWeightNorm();
-          scale(temp);
-          softDatedSum[c] += temp;
-        }
-      }
-      for (auto node : this->getPrunedSpeciesNodes()) {
-        auto e = node->node_index;
-        auto p = node->parent ? node->parent->node_index : e;
-        if (e != p) {
-          for (size_t c = 0; c < _gammaCatNumber; ++c) {
-            auto pc = p * _gammaCatNumber + c;
-            auto ec = e * _gammaCatNumber + c;
-            correctionSum[ec] = softDatedSums[pc];
-          }
-        }
-      }
-    }
-    for (size_t c = 0; c < _gammaCatNumber; ++c) {
-      clv._survivingTransferSum[c] = sums[c];
     }
   }
 }
 
-template <class REAL> void UndatedDTLMultiModel<REAL>::updateCLVs() {
-  for (CID cid = 0; cid < this->_ccp.getCladesNumber(); ++cid) {
-    updateCLV(cid);
-  }
-}
-
+/**
+ *  Update the list of the allowed transfer-receiving species
+ *  for each species branch
+ */
 template <class REAL>
-double UndatedDTLMultiModel<REAL>::computeLogLikelihood() {
-  if (this->_ccp.skip()) {
-    return 0.0;
+void UndatedDTLMultiModel<REAL>::updateTransferCandidates() {
+  for (auto &speciesTransferCandidates : _transferCandidateSpeciesNodes) {
+    speciesTransferCandidates.clear();
   }
-  auto hash = this->getHash();
-  auto cacheIt = _llCache.find(hash);
-  if (cacheIt != _llCache.end()) {
-    return cacheIt->second;
-  }
-
-  this->beforeComputeLogLikelihood();
-  if (this->_memorySavings) {
-    allocateMemory();
-  }
-  updateCLVs();
-  auto rootCID = this->_ccp.getCladesNumber() - 1;
-  std::vector<REAL> categoryLikelihoods(_gammaCatNumber, REAL());
-
   for (auto speciesNode : this->getPrunedSpeciesNodes()) {
     auto e = speciesNode->node_index;
-    for (size_t c = 0; c < _gammaCatNumber; ++c) {
-      categoryLikelihoods[c] +=
-          _dtlclvs[rootCID]._uq[e * _gammaCatNumber + c] * _OP[e];
-    }
-  }
-  // condition on survival
-  for (unsigned int c = 0; c < _gammaCatNumber; ++c) {
-    categoryLikelihoods[c] /= getLikelihoodFactor(c);
-  }
-  // sum over the categories
-  REAL res = std::accumulate(categoryLikelihoods.begin(),
-                             categoryLikelihoods.end(), REAL());
-  // normalize by the number of categories
-  res /= double(_gammaCatNumber);
-  // ths root correction makes sure that UndatedDTLMultiModel and
-  // UndatedDTL model are equivalent when there is one tree per
-  // family: the UndatedDTLMultiModel integrates over all possible
-  // roots and adds a 1/numberOfGeneRoots weight that is not
-  // present un the UndatedDTL, so we multiply back here
-  auto rootCorrection = double(this->getPrunedSpeciesNodeNumber());
-  res *= rootCorrection;
-  auto ret = log(res);
-  _llCache[hash] = ret;
-  if (this->_memorySavings) {
-    deallocateMemory();
-  }
-  return ret;
-}
-
-template <class REAL>
-bool UndatedDTLMultiModel<REAL>::sampleTransferEvent(
-    unsigned int cid, corax_rnode_t *originSpeciesNode, size_t category,
-    Scenario::Event &event) {
-  auto e = originSpeciesNode->node_index;
-  auto N = this->getPrunedSpeciesNodeNumber();
-  auto c = category;
-  auto ec = e * _gammaCatNumber + c;
-  auto &clv = _dtlclvs[cid];
-  auto &survivingTransferSum = clv._survivingTransferSum;
-  auto &correctionSum = clv._correctionSum;
-  REAL max = REAL();
-  switch (_transferConstraint) {
-  case TransferConstaint::NONE:
-    max = survivingTransferSum[c];
-    break;
-  case TransferConstaint::PARENTS:
-    max = survivingTransferSum[c] - correctionSum[ec];
-    break;
-  case TransferConstaint::RELDATED:
-    max = correctionSum[ec] * static_cast<REAL>(N);
-    break;
-  default:
-    assert(false);
-  }
-  auto samplingProba = Random::getProba();
-  max *= samplingProba;
-  REAL sum = REAL();
-
-  std::unordered_set<unsigned int> parents;
-  if (_transferConstraint == TransferConstaint::PARENTS) {
-    auto parent = originSpeciesNode;
-    while (parent) {
-      parents.insert(parent->node_index);
-      parent = parent->parent;
-    }
-  }
-
-  for (auto speciesNode : this->getPrunedSpeciesNodes()) {
-    auto h = speciesNode->node_index;
     if (_transferConstraint == TransferConstaint::NONE) {
+      // include all the species nodes except for the self
+      for (auto destSpeciesNode : this->getPrunedSpeciesNodes()) {
+        auto d = destSpeciesNode->node_index;
+        if (d == e) {
+          continue;
+        }
+        _transferCandidateSpeciesNodes[e].push_back(destSpeciesNode);
+      }
     }
-    // parent mode: do not continue if the receiving species
-    // is a parent of the source species
     if (_transferConstraint == TransferConstaint::PARENTS) {
-      if (parents.end() != parents.find(h)) {
-        continue;
+      // identify all parents of the self
+      std::unordered_set<unsigned int> parents;
+      auto parent = speciesNode;
+      while (parent) {
+        parents.insert(parent->node_index);
+        parent = parent->parent;
+      }
+      // include all the species nodes except for the parents
+      for (auto destSpeciesNode : this->getPrunedSpeciesNodes()) {
+        auto d = destSpeciesNode->node_index;
+        if (parents.end() != parents.find(d)) {
+          continue;
+        }
+        _transferCandidateSpeciesNodes[e].push_back(destSpeciesNode);
       }
     }
     if (_transferConstraint == TransferConstaint::RELDATED) {
-      if (originSpeciesNode->parent) {
-        auto p = originSpeciesNode->parent->node_index;
-        if (_datedTree.getRank(p) >= _datedTree.getRank(h)) {
+      // include all the species nodes younger than the self's parent
+      for (auto destSpeciesNode : this->getPrunedSpeciesNodes()) {
+        auto d = destSpeciesNode->node_index;
+        if (!_datedTree.canTransferUnderRelDated(e, d)) {
           continue;
         }
+        _transferCandidateSpeciesNodes[e].push_back(destSpeciesNode);
       }
     }
-    auto hc = h * _gammaCatNumber + c;
-    sum += _dtlclvs[cid]._uq[hc];
-    if (sum > max) {
-      event.pllDestSpeciesNode = speciesNode;
-      ;
-      event.destSpeciesNode = h;
-      return true;
-    }
   }
-  return false;
 }
 
+/**
+ *  Compute the per species branch probabilities of
+ *  the elementary events of clade evolution
+ */
 template <class REAL>
 void UndatedDTLMultiModel<REAL>::recomputeSpeciesProbabilities() {
+  auto allSpeciesNumber = this->getAllSpeciesNodeNumber();
+  // recompute _PD, _PL, _PT, _PS and highway.proba
   auto &dupRates = _dtlRates[0];
   auto &lossRates = _dtlRates[1];
   auto &transferRates = _dtlRates[2];
-  auto maxSpeciesId = this->_speciesTree.getNodeNumber();
-  assert(maxSpeciesId == dupRates.size());
-  assert(maxSpeciesId == lossRates.size());
-  assert(maxSpeciesId == transferRates.size());
-  for (auto speciesNode : this->getPrunedSpeciesNodes()) {
-    auto e = speciesNode->node_index;
-    for (size_t c = 0; c < _gammaCatNumber; ++c) {
+  assert(allSpeciesNumber == dupRates.size());
+  assert(allSpeciesNumber == lossRates.size());
+  assert(allSpeciesNumber == transferRates.size());
+  std::fill(_PD.begin(), _PD.end(), 0.0);
+  std::fill(_PL.begin(), _PL.end(), 0.0);
+  std::fill(_PT.begin(), _PT.end(), 0.0);
+  std::fill(_PS.begin(), _PS.end(), 0.0);
+  for (unsigned int c = 0; c < _gammaCatNumber; ++c) {
+    for (auto speciesNode : this->getPrunedSpeciesNodes()) {
+      auto e = speciesNode->node_index;
       auto ec = e * _gammaCatNumber + c;
       _PD[ec] = dupRates[e];
       _PL[ec] = lossRates[e];
@@ -456,188 +325,195 @@ void UndatedDTLMultiModel<REAL>::recomputeSpeciesProbabilities() {
       _PS[ec] /= sum;
       for (auto &highway : _highways[e]) {
         assert(highway.highway.proba >= 0.0);
-        highway.proba = highway.highway.proba / sum;
-        assert(highway.proba < 1.0);
+        // highway proba, normalized per category
+        highway.proba[c] = highway.highway.proba / sum;
+        assert(highway.proba[c] < 1.0);
       }
     }
   }
-
+  // recompute _OP
   std::vector<corax_rnode_t *> speciesNodesBuffer;
-  std::vector<corax_rnode_t *> *possibleSpeciesRootNodes = nullptr;
+  std::vector<corax_rnode_t *> *possibleOriginationSpeciesNodes = nullptr;
   switch (_originationStrategy) {
   case OriginationStrategy::UNIFORM:
   case OriginationStrategy::OPTIMIZE:
-    possibleSpeciesRootNodes = &(this->getPrunedSpeciesNodes());
+    possibleOriginationSpeciesNodes = &(this->getPrunedSpeciesNodes());
     break;
   case OriginationStrategy::ROOT:
     speciesNodesBuffer.push_back(this->_speciesTree.getRoot());
-    possibleSpeciesRootNodes = &speciesNodesBuffer;
+    possibleOriginationSpeciesNodes = &speciesNodesBuffer;
     break;
   case OriginationStrategy::LCA:
-    speciesNodesBuffer.push_back(this->getSpeciesLCA());
-    possibleSpeciesRootNodes = &speciesNodesBuffer;
+    speciesNodesBuffer.push_back(this->getCoveredSpeciesLCA());
+    possibleOriginationSpeciesNodes = &speciesNodesBuffer;
     break;
   }
+  std::fill(_OP.begin(), _OP.end(), 0.0);
   if (_originationStrategy == OriginationStrategy::OPTIMIZE) {
+    auto &oriRates = _dtlRates[3];
+    assert(allSpeciesNumber == oriRates.size());
     double sum = 0.0;
-    for (auto speciesNode : *possibleSpeciesRootNodes) {
-      sum += _dtlRates[3][speciesNode->node_index];
+    for (auto speciesNode : *possibleOriginationSpeciesNodes) {
+      auto e = speciesNode->node_index;
+      sum += oriRates[e];
     }
-    sum /= static_cast<double>(this->getPrunedSpeciesNodes().size());
-    for (auto speciesNode : *possibleSpeciesRootNodes) {
-      _OP[speciesNode->node_index] =
-          _dtlRates[3][speciesNode->node_index] / sum;
+    for (auto speciesNode : *possibleOriginationSpeciesNodes) {
+      auto e = speciesNode->node_index;
+      _OP[e] = oriRates[e] / sum;
     }
   } else {
-    std::fill(_OP.begin(), _OP.end(), 0.0);
-    for (auto speciesNode : *possibleSpeciesRootNodes) {
-      _OP[speciesNode->node_index] = 1.0;
+    double sum = static_cast<double>(possibleOriginationSpeciesNodes->size());
+    for (auto speciesNode : *possibleOriginationSpeciesNodes) {
+      auto e = speciesNode->node_index;
+      _OP[e] = 1.0 / sum;
     }
   }
+  // recompute _uE and _tE
+  updateTransferCandidates();
   std::fill(_uE.begin(), _uE.end(), REAL());
-  auto transferSum = std::vector<REAL>(_gammaCatNumber, REAL());
+  std::fill(_tE.begin(), _tE.end(), REAL());
+  // iterate several times to resolve _uE and _tE probas with
+  // fixed point optimization
   unsigned int maxIt = 4;
   for (unsigned int it = 0; it < maxIt; ++it) {
-    for (auto speciesNode : this->getPrunedSpeciesNodes()) {
-      auto e = speciesNode->node_index;
-      for (size_t c = 0; c < _gammaCatNumber; ++c) {
+    for (unsigned int c = 0; c < _gammaCatNumber; ++c) {
+      // postorder species tree traversal is granted
+      for (auto speciesNode : this->getPrunedSpeciesNodes()) {
+        auto e = speciesNode->node_index;
         auto ec = e * _gammaCatNumber + c;
-        if (it == maxIt - 1 && !speciesNode->left) {
-          _uE[ec] = _uE[ec] * (1.0 - this->_fm[e]) + REAL(this->_fm[e]);
-          scale(_uE[ec]);
+        REAL temp;
+        REAL proba = REAL();
+        // L scenario
+        temp = REAL(_PL[ec]);
+        scale(temp);
+        proba += temp;
+        // S scenario
+        if (this->getSpeciesLeft(speciesNode)) {
+          // internal branch
+          auto f = this->getSpeciesLeft(speciesNode)->node_index;
+          auto g = this->getSpeciesRight(speciesNode)->node_index;
+          auto fc = f * _gammaCatNumber + c;
+          auto gc = g * _gammaCatNumber + c;
+          temp = _uE[fc] * (_uE[gc] * _PS[ec]); // SEE scenario
         } else {
-          // L
-          REAL proba(_PL[ec]);
-          REAL temp;
-          // D
-          temp = _uE[ec] * _uE[ec] * _PD[ec];
+          // terminal branch
+          temp = REAL(_PS[ec] * this->_fm[e]); // S but not observed scenario
+        }
+        scale(temp);
+        proba += temp;
+        // DEE scenario
+        temp = _uE[ec] * (_uE[ec] * _PD[ec]);
+        scale(temp);
+        proba += temp;
+        // TEE scenario
+        temp = _uE[ec] * (_tE[ec] * _PT[ec]);
+        scale(temp);
+        proba += temp;
+        // highway TEE scenario
+        for (const auto &highway : _highways[e]) {
+          auto d = highway.highway.dest->node_index;
+          auto dc = d * _gammaCatNumber + c;
+          temp = _uE[ec] * (_uE[dc] * highway.proba[c]);
           scale(temp);
           proba += temp;
-          // T
-          temp = _uEBar[ec] * _uE[ec] * _PT[ec];
-          scale(temp);
-          proba += temp;
-          // S
-          if (this->getSpeciesLeft(speciesNode)) {
-            auto g = this->getSpeciesLeft(speciesNode)->node_index;
-            auto h = this->getSpeciesRight(speciesNode)->node_index;
-            auto gc = g * _gammaCatNumber + c;
-            auto hc = h * _gammaCatNumber + c;
-            temp = _uE[gc] * _uE[hc] * _PS[ec];
-            scale(temp);
-            proba += temp;
-          }
-          // transfer highway
-          for (const auto &highway : _highways[e]) {
-            auto d = highway.highway.dest->node_index;
-            auto dc = d * _gammaCatNumber + c;
-            temp = _uE[ec] * _uE[dc] * highway.proba;
-            scale(temp);
-            proba += temp;
-          }
-          _uE[ec] = proba;
-          if (!(proba < REAL(1.0))) {
-            std::cerr << "hey " << proba << " < " << REAL(1.0) << " is wrong"
-                      << std::endl;
-          }
-          assert(proba < REAL(1.000001));
         }
+        assert(proba < REAL(1.000001));
+        _uE[ec] = proba;
       }
-    }
-    // now compute transfer sum for the next iteration
-    if (it < maxIt - 1) {
-      // precompute ancestral correction sum
-      // (to forbid transfers to parents)
-      std::fill(transferSum.begin(), transferSum.end(), REAL());
+      // now that we've got extinction probas for every species branch,
+      // we can compute transfer-extinction probas
       for (auto speciesNode : this->getPrunedSpeciesNodes()) {
         auto e = speciesNode->node_index;
-        for (size_t c = 0; c < _gammaCatNumber; ++c) {
-          auto ec = e * _gammaCatNumber + c;
-          transferSum[c] += _uE[ec];
+        auto ec = e * _gammaCatNumber + c;
+        REAL proba = REAL();
+        for (auto destSpeciesNode : _transferCandidateSpeciesNodes[e]) {
+          auto d = destSpeciesNode->node_index;
+          auto dc = d * _gammaCatNumber + c;
+          proba += _uE[dc];
         }
-      }
-      std::fill(_uEBar.begin(), _uEBar.end(), REAL());
-      std::vector<double> correctionNorm(this->_speciesTree.getNodeNumber() *
-                                             _gammaCatNumber,
-                                         getTransferWeightNorm());
-      if (_transferConstraint == TransferConstaint::PARENTS) {
-        auto postOrder = this->_speciesTree.getPostOrderNodes();
-        for (auto it = postOrder.rbegin(); it != postOrder.rend(); ++it) {
-          auto speciesNode = *it;
-          auto e = speciesNode->node_index;
-          for (size_t c = 0; c < _gammaCatNumber; ++c) {
-            auto parent = speciesNode;
-            auto ec = e * _gammaCatNumber + c;
-            while (parent) {
-              correctionNorm[ec] -= 1.0;
-              auto p = parent->node_index;
-              auto pc = p * _gammaCatNumber + c;
-              auto temp = _uE[pc];
-              scale(temp);
-              _uEBar[ec] += temp;
-              parent = parent->parent;
-            }
-          }
-        }
-      } else {
-        assert(false);
-      }
-      for (auto speciesNode : this->getPrunedSpeciesNodes()) {
-        auto e = speciesNode->node_index;
-        for (size_t c = 0; c < _gammaCatNumber; ++c) {
-          auto ec = e * _gammaCatNumber + c;
-          _uEBar[ec] = (transferSum[c] - _uEBar[ec]) / correctionNorm[ec];
-        }
+        proba /= getTransferWeightNorm(e);
+        scale(proba);
+        assert(proba < REAL(1.000001));
+        _tE[ec] = proba;
       }
     }
-  } // iterations to account for TL
+  } // end of iteration
 }
 
+/**
+ *  Correction factor to the species tree likelihood,
+ *  because we condition on survival
+ */
 template <class REAL>
-REAL UndatedDTLMultiModel<REAL>::getTransferSum(unsigned int cid,
-                                                unsigned int e,
-                                                unsigned int c) {
-  auto ec = e * _gammaCatNumber + c;
-  switch (_transferConstraint) {
-  case TransferConstaint::NONE:
-    return _dtlclvs[cid]._survivingTransferSum[c] / getTransferWeightNorm();
-  case TransferConstaint::PARENTS:
-    return (_dtlclvs[cid]._survivingTransferSum[c] -
-            _dtlclvs[cid]._correctionSum[ec]) /
-           _dtlclvs[cid]._correctionNorm[ec];
-  case TransferConstaint::RELDATED:
-    return _dtlclvs[cid]._correctionSum[ec];
-  default:
-    assert(false);
+double UndatedDTLMultiModel<REAL>::getLikelihoodFactor(unsigned int category) {
+  double factor(0.0);
+  auto c = category;
+  for (auto speciesNode : this->getPrunedSpeciesNodes()) {
+    auto e = speciesNode->node_index;
+    auto ec = e * _gammaCatNumber + c;
+    factor += (1.0 - _uE[ec]) * _OP[e];
   }
+  return factor;
 }
 
+/**
+ *  Probability of the current family to evolve starting
+ *  from a given species branch
+ */
+template <class REAL>
+REAL UndatedDTLMultiModel<REAL>::getRootCladeLikelihood(
+    corax_rnode_t *speciesNode, unsigned int category) {
+  auto rootCID = this->_ccp.getCladesNumber() - 1;
+  auto c = category;
+  auto e = speciesNode->node_index;
+  auto ec = e * _gammaCatNumber + c;
+  REAL likelihood = _dtlclvs[rootCID]._uq[ec] * _OP[e];
+  scale(likelihood);
+  return likelihood;
+}
+
+/**
+ *  Sample a transfer destination species branch and
+ *  write it into the given recCell event
+ */
+template <class REAL>
+bool UndatedDTLMultiModel<REAL>::sampleTransferEvent(
+    unsigned int cid, corax_rnode_t *srcSpeciesNode, unsigned int category,
+    Scenario::Event &event) {
+  auto c = category;
+  auto e = srcSpeciesNode->node_index;
+  auto ec = e * _gammaCatNumber + c;
+  auto survivingTransferSum = _dtlclvs[cid]._tq[ec] * getTransferWeightNorm(e);
+  auto toSample = this->getRandom(survivingTransferSum);
+  auto sumProba = REAL();
+  for (auto destSpeciesNode : _transferCandidateSpeciesNodes[e]) {
+    auto d = destSpeciesNode->node_index;
+    auto dc = d * _gammaCatNumber + c;
+    sumProba += _dtlclvs[cid]._uq[dc];
+    if (sumProba > toSample) {
+      event.destSpeciesNode = d;
+      event.pllDestSpeciesNode = destSpeciesNode;
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ *  Compute the CLV value for a given cid (clade id) and a given
+ *  species node and write it to the proba variable
+ */
 template <class REAL>
 bool UndatedDTLMultiModel<REAL>::computeProbability(
-    CID cid, corax_rnode_t *speciesNode, size_t category, REAL &proba,
+    CID cid, corax_rnode_t *speciesNode, unsigned int category, REAL &proba,
     ReconciliationCell<REAL> *recCell) {
   proba = REAL();
-  bool isSpeciesLeaf = !this->getSpeciesLeft(speciesNode);
-  auto e = speciesNode->node_index;
-  auto c = category;
-  auto ec = e * _gammaCatNumber + c;
-  REAL maxProba = REAL();
-  if (recCell) {
-    recCell->event.geneNode = cid;
-    recCell->event.speciesNode = e;
-    recCell->event.type = ReconciliationEventType::EVENT_None;
-    maxProba = recCell->maxProba;
-  }
-  if (this->_ccp.isLeaf(cid) && isSpeciesLeaf) {
-    if (this->_geneToSpecies[cid] == e) {
-      proba = REAL(_PS[ec]);
-      if (recCell) {
-        recCell->event.label = this->_ccp.getLeafLabel(cid);
-      }
-    }
-    return true;
-  }
   REAL temp;
+  bool isGeneLeaf = this->_ccp.isLeaf(cid);
+  bool isSpeciesLeaf = !this->getSpeciesLeft(speciesNode);
+  auto c = category;
+  auto e = speciesNode->node_index;
+  auto ec = e * _gammaCatNumber + c;
   unsigned int f = 0;
   unsigned int g = 0;
   unsigned int fc = 0;
@@ -648,14 +524,36 @@ bool UndatedDTLMultiModel<REAL>::computeProbability(
     fc = f * _gammaCatNumber + c;
     gc = g * _gammaCatNumber + c;
   }
-
-  // iterate over all gene CCPs
+  REAL maxProba = REAL();
+  if (recCell) {
+    recCell->event.geneNode = cid;
+    recCell->event.speciesNode = e;
+    maxProba = recCell->maxProba;
+  }
+  // S events on terminal species branches can happen
+  // for terminal gene nodes only:
+  if (isGeneLeaf) {
+    // - S event on a terminal species branch (only for compatible genes and
+    // species)
+    if (isSpeciesLeaf && this->_geneToSpecies[cid] == e) {
+      temp = REAL(_PS[ec]);
+      scale(temp);
+      proba += temp;
+      if (recCell && proba > maxProba) {
+        recCell->event.type = ReconciliationEventType::EVENT_None;
+        recCell->event.label = this->_ccp.getLeafLabel(cid);
+        return true;
+      }
+    }
+  }
+  // S events on internal species branches, D events and T events can happen
+  // for ancestral gene nodes only:
   for (const auto &cladeSplit : this->_ccp.getCladeSplits(cid)) {
     auto cidLeft = cladeSplit.left;
     auto cidRight = cladeSplit.right;
     auto freq = cladeSplit.frequency;
-    if (not isSpeciesLeaf) {
-      // S event;
+    // - S event on an internal species branch
+    if (!isSpeciesLeaf) {
       temp = _dtlclvs[cidLeft]._uq[fc] * _dtlclvs[cidRight]._uq[gc] *
              (_PS[ec] * freq);
       scale(temp);
@@ -676,12 +574,12 @@ bool UndatedDTLMultiModel<REAL>::computeProbability(
         recCell->event.type = ReconciliationEventType::EVENT_S;
         recCell->event.leftGeneIndex = cidRight;
         recCell->event.rightGeneIndex = cidLeft;
-        recCell->blLeft = cladeSplit.blLeft;
-        recCell->blRight = cladeSplit.blRight;
+        recCell->blLeft = cladeSplit.blRight;
+        recCell->blRight = cladeSplit.blLeft;
         return true;
       }
     }
-    // D event
+    // - D event
     temp = _dtlclvs[cidLeft]._uq[ec] * _dtlclvs[cidRight]._uq[ec] *
            (_PD[ec] * freq);
     scale(temp);
@@ -694,27 +592,9 @@ bool UndatedDTLMultiModel<REAL>::computeProbability(
       recCell->blRight = cladeSplit.blRight;
       return true;
     }
-    // T event
-    temp = getTransferSum(cidLeft, e, c) * (_PT[ec] * freq);
-    temp *= _dtlclvs[cidRight]._uq[ec];
-    scale(temp);
-    proba += temp;
-    if (recCell && proba > maxProba) {
-      recCell->event.type = ReconciliationEventType::EVENT_T;
-
-      if (!sampleTransferEvent(cidLeft, speciesNode, c, recCell->event)) {
-        return false;
-      }
-      recCell->event.destSpeciesNode =
-          recCell->event.pllDestSpeciesNode->node_index;
-      recCell->event.leftGeneIndex = cidRight;
-      recCell->event.rightGeneIndex = cidLeft;
-      recCell->blLeft = cladeSplit.blLeft;
-      recCell->blRight = cladeSplit.blRight;
-      return true;
-    }
-    temp = getTransferSum(cidRight, e, c) * (_PT[ec] * freq);
-    temp *= _dtlclvs[cidLeft]._uq[ec];
+    // - T event
+    temp = _dtlclvs[cidLeft]._uq[ec] * _dtlclvs[cidRight]._tq[ec] *
+           (_PT[ec] * freq);
     scale(temp);
     proba += temp;
     if (recCell && proba > maxProba) {
@@ -722,68 +602,81 @@ bool UndatedDTLMultiModel<REAL>::computeProbability(
       if (!sampleTransferEvent(cidRight, speciesNode, c, recCell->event)) {
         return false;
       }
-      recCell->event.destSpeciesNode =
-          recCell->event.pllDestSpeciesNode->node_index;
       recCell->event.leftGeneIndex = cidLeft;
       recCell->event.rightGeneIndex = cidRight;
       recCell->blLeft = cladeSplit.blLeft;
       recCell->blRight = cladeSplit.blRight;
       return true;
     }
-
-    // highway transfers
+    temp = _dtlclvs[cidRight]._uq[ec] * _dtlclvs[cidLeft]._tq[ec] *
+           (_PT[ec] * freq);
+    scale(temp);
+    proba += temp;
+    if (recCell && proba > maxProba) {
+      recCell->event.type = ReconciliationEventType::EVENT_T;
+      if (!sampleTransferEvent(cidLeft, speciesNode, c, recCell->event)) {
+        return false;
+      }
+      recCell->event.leftGeneIndex = cidRight;
+      recCell->event.rightGeneIndex = cidLeft;
+      recCell->blLeft = cladeSplit.blRight;
+      recCell->blRight = cladeSplit.blLeft;
+      return true;
+    }
+    // - highway T event
     for (const auto &highway : _highways[e]) {
       auto d = highway.highway.dest->node_index;
       auto dc = d * _gammaCatNumber + c;
-      temp = (_dtlclvs[cidLeft]._uq[ec] * _dtlclvs[cidRight]._uq[dc]) *
-             (highway.proba * freq);
+      temp = _dtlclvs[cidLeft]._uq[ec] * _dtlclvs[cidRight]._uq[dc] *
+             (highway.proba[c] * freq);
       scale(temp);
       proba += temp;
       if (proba > REAL(1.0)) {
         std::cerr << "error " << _dtlclvs[cidLeft]._uq[ec] << " "
-                  << _dtlclvs[cidRight]._uq[dc] << " " << highway.proba << " "
-                  << freq << std::endl;
+                  << _dtlclvs[cidRight]._uq[dc] << " " << highway.proba[c]
+                  << " " << freq << std::endl;
       }
       if (recCell && proba > maxProba) {
         recCell->event.type = ReconciliationEventType::EVENT_T;
-        recCell->event.pllDestSpeciesNode = this->_speciesTree.getNode(d);
         recCell->event.destSpeciesNode = d;
+        recCell->event.pllDestSpeciesNode = highway.highway.dest;
         recCell->event.leftGeneIndex = cidLeft;
         recCell->event.rightGeneIndex = cidRight;
         recCell->blLeft = cladeSplit.blLeft;
         recCell->blRight = cladeSplit.blRight;
         return true;
       }
-      temp = (_dtlclvs[cidRight]._uq[ec] * _dtlclvs[cidLeft]._uq[dc]) *
-             (highway.proba * freq);
+      temp = _dtlclvs[cidRight]._uq[ec] * _dtlclvs[cidLeft]._uq[dc] *
+             (highway.proba[c] * freq);
       scale(temp);
       proba += temp;
       if (proba > REAL(1.0)) {
         std::cerr << "error " << _dtlclvs[cidRight]._uq[ec] << " "
-                  << _dtlclvs[cidLeft]._uq[dc] << " " << highway.proba << " "
+                  << _dtlclvs[cidLeft]._uq[dc] << " " << highway.proba[c] << " "
                   << freq << std::endl;
       }
       if (recCell && proba > maxProba) {
         recCell->event.type = ReconciliationEventType::EVENT_T;
-        recCell->event.pllDestSpeciesNode = this->_speciesTree.getNode(d);
         recCell->event.destSpeciesNode = d;
+        recCell->event.pllDestSpeciesNode = highway.highway.dest;
         recCell->event.leftGeneIndex = cidRight;
         recCell->event.rightGeneIndex = cidLeft;
-        recCell->blLeft = cladeSplit.blLeft;
-        recCell->blRight = cladeSplit.blRight;
+        recCell->blLeft = cladeSplit.blRight;
+        recCell->blRight = cladeSplit.blLeft;
         return true;
       }
     }
-  } // end of the iteraiton over the gene CCPs
-
-  if (not isSpeciesLeaf) {
-    // SL event
+  }
+  // SL events, DL events and TL events can happen
+  // for any of gene nodes:
+  // - SL event (only on an internal species branch)
+  if (!isSpeciesLeaf) {
     temp = _dtlclvs[cid]._uq[fc] * (_uE[gc] * _PS[ec]);
     scale(temp);
     proba += temp;
     if (recCell && proba > maxProba) {
       recCell->event.type = ReconciliationEventType::EVENT_SL;
-      recCell->event.destSpeciesNode = f;
+      recCell->event.lostSpeciesNode = g;
       recCell->event.pllDestSpeciesNode = this->getSpeciesLeft(speciesNode);
       recCell->event.pllLostSpeciesNode = this->getSpeciesRight(speciesNode);
       return true;
@@ -793,41 +686,39 @@ bool UndatedDTLMultiModel<REAL>::computeProbability(
     proba += temp;
     if (recCell && proba > maxProba) {
       recCell->event.type = ReconciliationEventType::EVENT_SL;
-      recCell->event.destSpeciesNode = g;
+      recCell->event.lostSpeciesNode = f;
       recCell->event.pllDestSpeciesNode = this->getSpeciesRight(speciesNode);
       recCell->event.pllLostSpeciesNode = this->getSpeciesLeft(speciesNode);
       return true;
     }
   }
-  // DL event
-  temp = _dtlclvs[cid]._uq[ec] * (2.0 * _uE[ec]) * _PD[ec];
-  scale(temp);
-  proba += temp;
-  if (recCell && proba > maxProba) {
-    recCell->event.type = ReconciliationEventType::EVENT_DL;
-    return true;
-  }
-  // TL event
-  if (!this->_info.noTL) {
-    // the gene is transfered to the dest species and goes extinct in
-    // the src species
-    temp = getTransferSum(cid, e, c) * (_PT[ec]);
-    temp *= _uE[ec];
-    scale(temp);
-    proba += temp;
-    if (recCell && proba > maxProba) {
-      recCell->event.type = ReconciliationEventType::EVENT_TL;
-      if (!sampleTransferEvent(cid, speciesNode, c, recCell->event)) {
-        return false;
+  if (this->_info.noTL) { // no TL events allowed
+    if (!this->_info.noDL) {
+      // - DL event
+      temp = proba / (1.0 - (_uE[ec] * _PD[ec] * 2.0));
+      scale(temp);
+      proba = temp;
+      if (recCell && proba > maxProba) {
+        // in fact, nothing happens, we'll have to resample
+        recCell->event.type = ReconciliationEventType::EVENT_DL;
+        return true;
       }
-      recCell->event.destSpeciesNode =
-          recCell->event.pllDestSpeciesNode->node_index;
-      return true;
     }
-    // the gene is transfered to the dest species and goes extinct in
-    // the dest species
-    temp = _dtlclvs[cid]._uq[ec] * (_PT[ec]);
-    temp *= _uEBar[ec];
+  } else { // TL events allowed
+    if (!this->_info.noDL) {
+      // - DL event
+      temp = _dtlclvs[cid]._uq[ec] * (_uE[ec] * _PD[ec] * 2.0);
+      scale(temp);
+      proba += temp;
+      if (recCell && proba > maxProba) {
+        // in fact, nothing happens, we'll have to resample
+        recCell->event.type = ReconciliationEventType::EVENT_DL;
+        return true;
+      }
+    }
+    // - TL event
+    // we transfer, but the gene gets extinct in the receiving species
+    temp = _dtlclvs[cid]._uq[ec] * (_tE[ec] * _PT[ec]);
     scale(temp);
     proba += temp;
     if (recCell && proba > maxProba) {
@@ -836,12 +727,23 @@ bool UndatedDTLMultiModel<REAL>::computeProbability(
       recCell->event.pllDestSpeciesNode = nullptr;
       return true;
     }
-    // TL from a highway
+    // we transfer, and the gene gets extinct in the sending species
+    temp = _dtlclvs[cid]._tq[ec] * (_uE[ec] * _PT[ec]);
+    scale(temp);
+    proba += temp;
+    if (recCell && proba > maxProba) {
+      recCell->event.type = ReconciliationEventType::EVENT_TL;
+      if (!sampleTransferEvent(cid, speciesNode, c, recCell->event)) {
+        return false;
+      }
+      return true;
+    }
+    // - highway TL event
     for (const auto &highway : _highways[e]) {
       auto d = highway.highway.dest->node_index;
       auto dc = d * _gammaCatNumber + c;
-      // we transfer but the gene gets extinct in the receiving species
-      temp = (_dtlclvs[cid]._uq[ec] * _uE[dc]) * highway.proba;
+      // we transfer, but the gene gets extinct in the receiving species
+      temp = _dtlclvs[cid]._uq[ec] * (_uE[dc] * highway.proba[c]);
       scale(temp);
       proba += temp;
       if (recCell && proba > maxProba) {
@@ -850,69 +752,28 @@ bool UndatedDTLMultiModel<REAL>::computeProbability(
         recCell->event.pllDestSpeciesNode = nullptr;
         return true;
       }
-      // we transfer and the gene gets extinct in the sending species
-      temp = (_dtlclvs[cid]._uq[dc] * _uE[ec]) * highway.proba;
+      // we transfer, and the gene gets extinct in the sending species
+      temp = _dtlclvs[cid]._uq[dc] * (_uE[ec] * highway.proba[c]);
       scale(temp);
       proba += temp;
       if (recCell && proba > maxProba) {
         recCell->event.type = ReconciliationEventType::EVENT_TL;
-        recCell->event.pllDestSpeciesNode = highway.highway.dest;
         recCell->event.destSpeciesNode = d;
+        recCell->event.pllDestSpeciesNode = highway.highway.dest;
         return true;
       }
     }
   }
-
   if (recCell) {
-    std::cerr << "boum " << proba << " " << maxProba << std::endl;
-    return false;
+    Logger::error << "error: proba=" << proba << ", maxProba=" << maxProba
+                  << " (proba < maxProba)" << std::endl;
+    return false; // we haven't sampled any event, this should not happen
   }
   if (proba > REAL(1.0)) {
+    Logger::error << "error: proba=" << proba << " (proba > 1)" << std::endl;
     return false;
   }
   return true;
-}
-
-/**
- *  Correction factor because we condition on survival
- */
-template <class REAL>
-double UndatedDTLMultiModel<REAL>::getLikelihoodFactor(unsigned int category) {
-  double factor(0.0);
-  for (auto speciesNode : this->getPrunedSpeciesNodes()) {
-    auto e = speciesNode->node_index;
-    factor += _OP[e * _gammaCatNumber + category] *
-              (1.0 - _uE[e * _gammaCatNumber + category]);
-  }
-  return factor;
-}
-
-template <class REAL>
-corax_rnode_t *
-UndatedDTLMultiModel<REAL>::sampleSpeciesNode(unsigned int &category) {
-  auto rootCID = this->_ccp.getCladesNumber() - 1;
-  auto &uq = _dtlclvs[rootCID]._uq;
-  REAL totalLL = REAL();
-  for (auto node : this->getPrunedSpeciesNodes()) {
-    auto e = node->node_index;
-    for (unsigned int c = 0; c < _gammaCatNumber; ++c) {
-      totalLL += uq[e * _gammaCatNumber + c] * _OP[e];
-    }
-  }
-  auto toSample = totalLL * Random::getProba();
-  auto sumLL = REAL();
-  for (auto node : this->getPrunedSpeciesNodes()) {
-    auto e = node->node_index;
-    for (unsigned int c = 0; c < _gammaCatNumber; ++c) {
-      sumLL += uq[e * _gammaCatNumber + c] * _OP[e];
-      if (sumLL >= toSample) {
-        category = c;
-        return node;
-      }
-    }
-  }
-  assert(false);
-  return nullptr;
 }
 
 template <class REAL> size_t UndatedDTLMultiModel<REAL>::getHash() {

--- a/src/ale/ale.cpp
+++ b/src/ale/ale.cpp
@@ -385,7 +385,7 @@ RecModelInfo buildRecModelInfo(const AleArguments &args) {
       -1.0,  // branch length threshold
       args.transferConstraint,
       false, // no dup (option specific to GeneRax)
-      args.noTL, args.fractionMissingFile, args.memorySavings);
+      args.noDL, args.noTL, args.fractionMissingFile, args.memorySavings);
 }
 
 Parameters buildStartingRates(const AleArguments &args,

--- a/src/ale/ale.cpp
+++ b/src/ale/ale.cpp
@@ -1,10 +1,11 @@
+#include <cstdio>
+
 #include <DistanceMethods/MiniNJ.hpp>
 #include <IO/FamiliesFileParser.hpp>
 #include <IO/FileSystem.hpp>
 #include <IO/Logger.hpp>
 #include <IO/ParallelOfstream.hpp>
 #include <ccp/ConditionalClades.hpp>
-#include <cstdio>
 #include <parallelization/ParallelContext.hpp>
 #include <util/Paths.hpp>
 #include <util/RecModelInfo.hpp>


### PR DESCRIPTION
**This pull request depends on the ? PR**

Together they introduce the following changes:
1. Organize the code so that the `MultiModel` class defines general-purpose functions and the `UndatedDLMultiModel` and `UndatedDTLMultiModel` classes define only the functions dependent on modelling transfer events. Thus, the functions `computeLogLikelihood`, `updateCLVs` and `sampleOriginationSpecies` (renamed from `sampleSpeciesNode`) are now defined in the `MultiModel` class.
2. Make sure that cached likelihoods are cleared upon model parameter changes. Thus, the functions `setAlpha`, `setRates` and `setHighways` now all call `invalidateAllSpeciesNodes()` and `resetCache()`. As cached CLVs are not reused in the current version, the `invalidateAllSpeciesNodes` function does not have any effect now, but the code is organized to easily make it work in the future.
3. Make sure that the branch event probabilities get updated when and only when needed. The `recomputeSpeciesProbabilities` function now is called only within the `beforeComputeCLVs` function (renamed form `beforeComputeLogLikelihood`), which in turn is called only within the `updateCLVs` function. Indeed, we need to call `updateCLVs()` only within the `computeLogLikelihood` and `sampleReconciliations` functions, which are used when the tree or the model has been altered or just initialized, and we need to update the branch event probabilities only and every time before computing the CLVs.
4. Make the `--memory-savings` option work properly. The original `deallocateMemory` function used `_dtlclvs.clear()`, however, this method does not free the allocated memory. Now the function uses reinitialization with an empty vector, which I think should be solving the problem (I haven't checked it, though).
5. Fix `UndatedDLMultiModel`. The model has not been working at all after some recent commits, and its original implementation had a number of problems which are now all fixed:
5.1. Add the missing origination probability multiplier in the `getLikelihoodFactor` function. 
5.2. Add support for the rate gamma categories.
5.3. Add support for likelihood caching.
5.4. Add support for the `--memory-savings` option.
5.5. Resort to the iterative calculation of branch extinction probabilities (`_uE`). The original `solveSecondDegreePolynome` function used a wrong formula for quadratic equation roots, yet using the right formula sometimes results in `_uE = 0.0`, expectedly leading to an error. Thus, the iterative calculation method (fixed point optimization) is the only solution here.
6. Fix `UndatedDTLMultiModel`. The original implementation of the model had a number of problems which are now all fixed (fix #16):
6.1. Add transfer probability for each rate gamma category in the `WeightedHighway` structure.
6.2. Simplify implementation of transfer-extinction probabilities and clade transfer likelihoods. Now the former are stored along with branch extinction probabilities (as `_tE` and `_uE` respectively) and the latter are part of the `DTLCLV` structure (as `_tq`). This exactly reproduces the description provided in the AleRax paper.
6.3. Simplify implementation of the transfer constraints. Now the `_transferCandidateSpeciesNodes` vector stores potential transfer destination species branches for each source species branch. The vector is calculated by the `updateTransferCandidates` function called within the `recomputeSpeciesProbabilities` function. The new implementation is easier and faster than the original implementation.
7. Fix the fraction missing (`_fm`) usage in both `UndatedDLMultiModel` and `UndatedDTLMultiModel`. I think there was a misconception regarding this parameter both in the code and in the paper. The `_fm` parameter vector can be specified with the `--fraction-missing-file` option for terminal species branches (_i.e._ extant species) and is useful for analyses including incomplete transcriptome/genome assemblies, as `_fm[e]` stands for the  probability that the extant species `e` has a gene copy, but the copy is not included in the current dataset, _i.e._ `P(unobserved|EVENT_Leaf)`. This definition has two important implications. First, `_fm` cannot appear anywhere in the `computeProbability` function, as CLVs can be calculated only for the **observed** gene copies and their gene ancestors. Second, an unobserved on-leaf speciation event looks like a copy extinction, thus for an extant species branch `_uE[e] = P(EVENT_L) + P(unobserved ^ EVENT_Leaf) = P(EVENT_L) + P(unobserved|EVENT_Leaf)P(EVENT_Leaf) = _pL[e] + _fm[e]*_pS[e]`. Now both implications are respected in the code.
8. Fix origination probabilities calculation for the `--origination` option in both `UndatedDLMultiModel` and `UndatedDTLMultiModel` so that the sum of origination probabilities (`_OP`) over all allowed species branches equals 1.0.
9. Introduce DL events to both `UndatedDLMultiModel` and `UndatedDTLMultiModel` so that they can be turned off with the `--no-dl` option. For `UndatedDTLMultiModel` the implementation depends also on modelling TL events (using `--no-tl` allows for the faster direct probability calculation method).
10. Add inference of DL and TL events for the case when the clade is a gene leaf and the branch is a species leaf (only S events were modelled for this case before in both `UndatedDLMultiModel` and `UndatedDTLMultiModel`).
11. Fix `recCell.blLeft` and `recCell.blRight` specifications for S, D and T events (they were mixed up in both `UndatedDLMultiModel` and `UndatedDTLMultiModel`).
12. Make sure that the `ScaledValue` variables get scaled whenever needed and that random sampling is error-proof. Regarding the latter: we use a random sampling threshold `T = full_sum * Random::getProba()` and sample `s_i` if `(s_1 + ... + s_i) > T`. Should the `Random::getProba()` function return a value too close to 1.0, then due to auto-rounding (the implementation of which is system-dependent) we can get into the situation where `T = full_sum` and, thus, we sample `s_i` if `(s_1 + ... + s_i) > full_sum` -- a condition that is never met. Now, to avoid this situation the newly introduced `MultiModel::getRandom` function converts the threshold `T` into zero in case `T = full_sum`.
13. Fix specification of the scenario `_lastEventType` buffer. Now the `_lastEventType` buffer is set only before the both `backtrace()` calls of S and D events, before the `backtrace()` call of SL events and before the destination species `backtrace()` call of T and TL events. The idea is that DL and destination-loss TL events are virtual (not sampled) and that T events do not affect the source branch in any way (as their source is usually an unobserved extinct sister species branch), thus none of these events should change our estimate of singleton genes on a given species branch.
14. Get rid of the `rootCorrection` multiplier in the `computeLogLikelihood` function. The correction is not needed and can result in LL > 0 (try to reconcile a gene tree and a species tree of the same topology). Indeed, as mentioned in Benoit's comment to the correction, while computing the root clade likelihood, we integrate over all gene root positions using clade split frequencies of the root clade as weights of these root positions. Thus, the computed root clade likelihood is, by definition, the total probability over possible gene tree rootings. Similarly, we integrate over all species branches where the gene tree could have originated and sum the respective root clade likelihoods weighted by the origination probabilities of those branches. The computed reconciliation likelihood is also the total probability, now over possible gene tree originations and rootings. There is no need for any further normalization, and no such normalization is mentioned in the AleRax paper.
The observed difference in the estimated likelihoods mentioned in Benoit's comment is, instead, a problem of `GTBaseReconciliationModel` in GeneRax which doesn't use weights while summing over root positions (but this is a job for an unrelated future PR to GeneRax).

These changes do not introduce any new features, but render the reconciliation models to work in accordance with the original description provided in the AleRax paper.
